### PR TITLE
[First Draft] Implement load balance feature in Python's Psycopg2 driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,23 +41,16 @@ or online for the details.
 If prerequisites are met, you can install psycopg like any other Python
 package, using ``pip`` to download it from PyPI_::
 
-    $ pip install psycopg2
+    $ pip install psycopg2-yugabytedb
 
 or using ``setup.py`` if you have downloaded the source package locally::
 
     $ python setup.py build
     $ sudo python setup.py install
 
-You can also obtain a stand-alone package, not requiring a compiler or
-external libraries, by installing the `psycopg2-binary`_ package from PyPI::
+Note - The YugabyteDB Psycopg2 requires Postgresql version 11 or above (preferrably 14)
 
-    $ pip install psycopg2-binary
-
-The binary package is a practical choice for development and testing but in
-production it is advised to use the package built from sources.
-
-.. _PyPI: https://pypi.org/project/psycopg2/
-.. _psycopg2-binary: https://pypi.org/project/psycopg2-binary/
+.. _PyPI: https://pypi.org/project/psycopg2-yugabytedb/
 .. _install: https://www.psycopg.org/docs/install.html#install-from-source
 .. _faq: https://www.psycopg.org/docs/faq.html#faq-compile
 
@@ -71,3 +64,55 @@ production it is advised to use the package built from sources.
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/psycopg/psycopg2?branch=master&svg=true
     :target: https://ci.appveyor.com/project/psycopg/psycopg2/branch/master
     :alt: Windows build status
+
+YugabyteDB Psycopg2 Features
+============================
+
+Yugabyte Psycopg2 driver is a distributed python driver for YSQL built on the PostgreSQL psycopg2 driver. Although the upstream PostgreSQL psycopg2 driver works with YugabyteDB, the Yugabyte driver enhances YugabyteDB by eliminating the need for external load balancers.
+
+* It is cluster-aware, which eliminates the need for an external load balancer.
+* It is topology-aware, which is essential for geographically-distributed applications. The driver uses servers that are part of a set of geo-locations specified by topology keys.
+
+Load balancing
+--------------
+
+The Yugabyte Psycopg2 driver has the following load balancing features:
+
+* Uniform load balancing
+
+In this mode, the driver makes the best effort to uniformly distribute the connections to each YugabyteDB server. For example, if a client application creates 100 connections to a YugabyteDB cluster consisting of 10 servers, then the driver creates 10 connections to each server. If the number of connections are not exactly divisible by the number of servers, then a few may have 1 less or 1 more connection than the others. This is the client view of the load, so the servers may not be well balanced if other client applications are not using the Yugabyte JDBC driver.
+
+* Topology-aware load balancing
+
+Because YugabyteDB clusters can have servers in different regions and availability zones, the YugabyteDB JDBC driver is topology-aware, and can be configured to create connections only on servers that are in specific regions and zones. This is useful for client applications that need to connect to the geographically nearest regions and availability zone for lower latency; the driver tries to uniformly load only those servers that belong to the specified regions and zone.
+The Yugabyte Psycopg2 driver can be configured with pooling as well.
+
+Usage
+-----
+
+Load balancing connection properties:
+
+The following connection properties need to be added to enable load balancing:
+
+* load_balance - enable cluster-aware load balancing by setting this property to True; disabled by default.
+* topology_keys - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as cloud.region.zone.
+
+Pass new connection properties for load balancing in the connection URL or in the dictionary. To enable uniform load balancing across all servers, you set the load-balance property to True in the URL, as per the following example.
+
+Connection String::
+
+    conn = psycopg2.connect("dbname=database_name host=hostname port=port user=username  password=password load_balance=true")
+
+Connection Dictionary::
+
+    conn = psycopg2.connect(user = 'username', password='xxx', host = 'hostname', port = 'port', dbname = 'database_name', load_balance='True')
+
+To specify topology keys, you set the topology_keys property to comma separated values, as per the following example.
+
+Connection String::
+
+    conn = psycopg2.connect("dbname=database_name host=hostname port=port user=username  password=password load_balance=true topology_keys=cloud1.region1.zone1,cloud2.region2.zone2")
+
+Connection Dictionary::
+
+    conn = psycopg2.connect(user = 'username', password='xxx', host = 'hostname', port = 'port', dbname = 'database_name', load_balance='True', topology_keys='cloud1.region1.zone1,cloud2.region2.zone2')

--- a/doc/src/connection.rst
+++ b/doc/src/connection.rst
@@ -899,7 +899,7 @@ The ``connection`` class
         Example::
 
             >>> conn.get_dsn_parameters()
-            {'dbname': 'test', 'user': 'postgres', 'port': '5432', 'sslmode': 'prefer'}
+            {'dbname': 'yugabyte', 'user': 'yugabyte', 'port': '5433', 'sslmode': 'prefer'}
 
         Requires libpq >= 9.3.
 

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -170,7 +170,7 @@ introspection etc.
         Example::
 
             >>> conn.info.dsn_parameters
-            {'dbname': 'test', 'user': 'postgres', 'port': '5433', 'sslmode': 'prefer'}
+            {'dbname': 'yugabyte', 'user': 'yugabyte', 'port': '5433', 'sslmode': 'prefer'}
 
         Requires libpq >= 9.3.
 

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -170,7 +170,7 @@ introspection etc.
         Example::
 
             >>> conn.info.dsn_parameters
-            {'dbname': 'test', 'user': 'postgres', 'port': '5432', 'sslmode': 'prefer'}
+            {'dbname': 'test', 'user': 'postgres', 'port': '5433', 'sslmode': 'prefer'}
 
         Requires libpq >= 9.3.
 

--- a/doc/src/module.rst
+++ b/doc/src/module.rst
@@ -41,7 +41,7 @@ The module interface respects the standard defined in the |DBAPI|_.
     - `!user` -- user name used to authenticate
     - `!password` -- password used to authenticate
     - `!host` -- database host address (defaults to UNIX socket if not provided)
-    - `!port` -- connection port number (defaults to 5432 if not provided)
+    - `!port` -- connection port number (defaults to 5433 if not provided)
 
     Any other connection parameter supported by the client library/server can
     be passed either in the connection string or as a keyword. The PostgreSQL

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -126,18 +126,19 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
         kwasync['async_'] = kwargs.pop('async_')
 
     lbprops = LoadBalanceProperties(dsn, **kwargs)
-    if lbprops.hasLoadBalanced() :
+    if lbprops.hasLoadBalance() :
         conn = getConnectionBalanced(lbprops, connection_factory, cursor_factory, **kwasync)
-        return conn
-    else :
+        if conn != None:
+            return conn
         print('Failed to apply load balancing, Trying normal connection')
-        dsn = lbprops.getStrippedDSN()
-        kwargs = lbprops.getStrippedProperties()
-        dsn = _ext.make_dsn(dsn, **kwargs)
-        conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
-        if cursor_factory is not None:
-            conn.cursor_factory = cursor_factory
-        return conn
+    
+    dsn = lbprops.getStrippedDSN()
+    kwargs = lbprops.getStrippedProperties()
+    dsn = _ext.make_dsn(dsn, **kwargs)
+    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+    if cursor_factory is not None:
+        conn.cursor_factory = cursor_factory
+    return conn
 
 def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kwasync):
     kwargs = lbprops.getStrippedProperties()

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -83,9 +83,6 @@ import re
 import psycopg2.extensions
 import threading
 
-# lock = threading.Lock()
-
-
 def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
     """
     Create a new database connection.
@@ -130,13 +127,10 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
 
     lbprops = LoadBalanceProperties(dsn, **kwargs)
     if lbprops.hasLoadBalanced() :
-        # lock.acquire()
-        # print('Is load Balanced')
         conn = getConnectionBalanced(lbprops, connection_factory, cursor_factory, **kwasync)
-        # lock.release()
         return conn
     else :
-        # print('Failed to apply load balancing, Trying normal connection')
+        print('Failed to apply load balancing, Trying normal connection')
         dsn = lbprops.getStrippedDSN()
         kwargs = lbprops.getStrippedProperties()
         dsn = _ext.make_dsn(dsn, **kwargs)
@@ -155,7 +149,6 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
     dsn = _ext.make_dsn(dsn,**kwargs)
 
     if chosenHost == '':
-        # dsn = _ext.make_dsn(dsn, **kwargs)
         controlConnection = _connect(dsn, connection_factory=connection_factory, **kwasync)
         if cursor_factory is not None:
             controlConnection.cursor_factory = cursor_factory
@@ -176,8 +169,6 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             PortRegex = re.compile(r'port( )*=( )*[0-9]*( )?')
             dsn = HostRegex.sub(host_parameter, dsn)
             dsn = PortRegex.sub(port_parameter, dsn)
-            # print('DSN',dsn)
-            # dsn = _ext.make_dsn(dsn, **kwargs)
             newconn = _connect(dsn, connection_factory=connection_factory, **kwasync)
             if cursor_factory is not None:
                 newconn.cursor_factory = cursor_factory

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -160,6 +160,9 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             loadbalancer.updateConnectionMap(dsnhost, 1)
             loadbalancer.updateConnectionMap(chosenHost, -1)
         controlConnection.close()
+
+        # Getting chosenHost again after refresh for the latest least loaded server
+        
         chosenHost = loadbalancer.getLeastLoadedServer(failedHosts)
     
     if chosenHost == '':

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -192,7 +192,7 @@ def getDSNWithChosenHost(loadbalancer, dsn, chosenHost):
     host_parameter = 'host=' + chosenHost + ' '
     port_parameter = 'port=' + str(port) + ' '
     HostRegex = re.compile(r'host( )*=( )*(\S)*( )?')
-    PortRegex = re.compile(r'port( )*=( )*[0-9]*( )?')
+    PortRegex = re.compile(r'port( )*=( )*[0-9]*(None)*( )?')
     dsn = HostRegex.sub(host_parameter, dsn)
     dsn = PortRegex.sub(port_parameter, dsn)
     return dsn

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -83,7 +83,7 @@ import re
 import psycopg2.extensions
 import threading
 
-lock = threading.Lock()
+# lock = threading.Lock()
 
 
 def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
@@ -130,10 +130,10 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
 
     lbprops = LoadBalanceProperties(dsn, **kwargs)
     if lbprops.hasLoadBalanced() :
-        lock.acquire()
+        # lock.acquire()
         # print('Is load Balanced')
         conn = getConnectionBalanced(lbprops, connection_factory, cursor_factory, **kwasync)
-        lock.release()
+        # lock.release()
         return conn
     else :
         # print('Failed to apply load balancing, Trying normal connection')

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -102,7 +102,7 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
     - *user*: user name used to authenticate
     - *password*: password used to authenticate
     - *host*: database host address (defaults to UNIX socket if not provided)
-    - *port*: connection port number (defaults to 5432 if not provided)
+    - *port*: connection port number (defaults to 5433 if not provided)
 
     Using the *connection_factory* parameter a different class or connections
     factory can be specified. It should be a callable object taking a dsn

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -121,6 +121,7 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
     library: the list of supported parameters depends on the library version.
 
     """
+    
     kwasync = {}
     if 'async' in kwargs:
         kwasync['async'] = kwargs.pop('async')
@@ -130,12 +131,12 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
     lbprops = LoadBalanceProperties(dsn, **kwargs)
     if lbprops.hasLoadBalanced() :
         lock.acquire()
-        print('Is load Balanced')
-        conn = getConnectionBalanced(lbprops, connection_factory, cursor_factory)
+        # print('Is load Balanced')
+        conn = getConnectionBalanced(lbprops, connection_factory, cursor_factory, **kwasync)
         lock.release()
         return conn
     else :
-        print('Failed to apply load balancing, Trying normal connection')
+        # print('Failed to apply load balancing, Trying normal connection')
         dsn = lbprops.getStrippedDSN()
         kwargs = lbprops.getStrippedProperties()
         dsn = _ext.make_dsn(dsn, **kwargs)
@@ -144,14 +145,8 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
             conn.cursor_factory = cursor_factory
         return conn
 
-def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None):
+def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kwasync):
     kwargs = lbprops.getStrippedProperties()
-    kwasync = {}
-    if 'async' in kwargs:
-        kwasync['async'] = kwargs.pop('async')
-    if 'async_' in kwargs:
-        kwasync['async_'] = kwargs.pop('async_')
-    
     loadbalancer = lbprops.getAppropriateLoadBalancer()
     dsn = lbprops.getStrippedDSN()
     unreachableHosts = loadbalancer.getUnreachableHosts()

--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -142,9 +142,14 @@ def make_dsn(dsn=None, **kwargs):
 
     # If no kwarg is specified don't mung the dsn, but verify it
     if not kwargs:
+        if not 'port' in dsn:
+            dsn += ' port=5433' 
         parse_dsn(dsn)
         return dsn
-
+    
+    #Set Default pot to 5433 if not specified
+    if not 'port' in kwargs:
+        kwargs['port'] = 5433
     # Override the dsn with the parameters
     if 'database' in kwargs:
         if 'dbname' in kwargs:

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -44,8 +44,8 @@ class LoadBalanceProperties:
                 tp_parts = list(filter(('').__ne__, tp_parts))
                 self.placements = tp_parts[1].strip()
                 sb = TopologyAwareRegex.sub('',sb)
-
         return sb
+        
     def processProperties(self):
         backup_dict = self.originalProperties
         if 'load_balance' in backup_dict:

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -1,0 +1,89 @@
+import re
+from psycopg2.policies import ClusterAwareLoadBalancer,TopologyAwareLoadBalancer
+class LoadBalanceProperties:
+
+    CONNECTION_MANAGER_MAP = {}
+
+    def __init__(self, dsn, **kwargs):
+        self.SIMPLE_LB = 'simple'
+        self.LOAD_BALANCE_PROPERTY_KEY = 'load-balance'
+        self.EQUALS = '='
+        self.originalDSN = dsn
+        self.originalProperties = kwargs
+        self.hasLoadBalance = False
+        self.placements = ''
+        self.ybProperties = {}
+        self.ybDSN = None
+        if self.originalDSN != None :
+            self.ybDSN = self.processURL()
+        else:
+            # print('Going to process properties')
+            self.ybProperties = self.processProperties()
+        
+
+    def processURL(self):
+        ClusterAwareRegex = re.compile(r'load_balance( )*=( )*([a-z]*[A-Z]*)*( )?')
+        lb_string = ClusterAwareRegex.search(self.originalDSN)
+        if lb_string == None :
+            return self.originalDSN
+        else:
+            lb_string = lb_string.group()
+            lb_parts = lb_string.split(self.EQUALS)
+            lb_parts = list(filter(('').__ne__, lb_parts))
+            propValue = lb_parts[1].lower().strip()
+            if propValue == 'true':
+                self.hasLoadBalance = True
+            sb = ClusterAwareRegex.sub('',self.originalDSN)
+
+            TopologyAwareRegex = re.compile(r'topology_keys( )*=( )*(\S)*( )?')
+            tp_string = TopologyAwareRegex.search(self.originalDSN)
+            if tp_string != None :
+                tp_string = tp_string.group()
+                tp_parts = tp_string.split(self.EQUALS)
+                tp_parts = list(filter(('').__ne__, tp_parts))
+                self.placements = tp_parts[1].strip()
+                sb = TopologyAwareRegex.sub('',sb)
+
+        return sb
+    def processProperties(self):
+        backup_dict = self.originalProperties
+        if 'load_balance' in backup_dict:
+            propValue = backup_dict.pop('load_balance')
+            propValue = propValue.lower().strip()
+            if propValue == 'true':
+                self.hasLoadBalance = True
+            if 'topology_keys' in backup_dict:
+                self.placements = backup_dict.pop('topology_keys')
+                # print('Placements', self.placements)
+        return backup_dict
+
+
+    def getOriginalDSN(self):
+        return self.originalDSN
+
+    def getStrippedDSN(self):
+        return self.ybDSN
+
+    def getOriginalProperties(self):
+        return self.originalProperties
+
+    def getStrippedProperties(self):
+        return self.ybProperties
+
+    def hasLoadBalanced(self):
+        return self.hasLoadBalance
+
+    def getAppropriateLoadBalancer(self):
+        if self.placements == '':
+            ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
+            if ld == None:
+                # print('Returning cluster aware load balancer')
+                ld = ClusterAwareLoadBalancer.getInstance()
+                LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
+        else:
+            ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.placements)
+            if ld == None :
+                # print('Returning topology aware load balancer')
+                ld = TopologyAwareLoadBalancer(self.placements)
+                LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.placements] = ld
+        return ld

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -19,7 +19,6 @@ class LoadBalanceProperties:
         if self.originalDSN != None :
             self.ybDSN = self.processURL()
         else:
-            # print('Going to process properties')
             self.ybProperties = self.processProperties()
         
 
@@ -56,7 +55,6 @@ class LoadBalanceProperties:
                 self.hasLoadBalance = True
             if 'topology_keys' in backup_dict:
                 self.placements = backup_dict.pop('topology_keys')
-                # print('Placements', self.placements)
         return backup_dict
 
 
@@ -79,13 +77,11 @@ class LoadBalanceProperties:
         if self.placements == '':
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
             if ld == None:
-                # print('Returning cluster aware load balancer')
                 ld = ClusterAwareLoadBalancer.getInstance()
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
         else:
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.placements)
             if ld == None :
-                # print('Returning topology aware load balancer')
                 ld = TopologyAwareLoadBalancer(self.placements)
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.placements] = ld
         return ld

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -8,11 +8,11 @@ class LoadBalanceProperties:
 
     def __init__(self, dsn, **kwargs):
         self.SIMPLE_LB = 'simple'
-        self.LOAD_BALANCE_PROPERTY_KEY = 'load-balance'
+        self.LOAD_BALANCE_PROPERTY_KEY = 'load_balance'
         self.EQUALS = '='
         self.originalDSN = dsn
         self.originalProperties = kwargs
-        self.hasLoadBalance = False
+        self.loadbalance = False
         self.placements = ''
         self.ybProperties = self.originalProperties
         self.ybDSN = None
@@ -33,7 +33,7 @@ class LoadBalanceProperties:
             lb_parts = list(filter(('').__ne__, lb_parts))
             propValue = lb_parts[1].lower().strip()
             if propValue == 'true':
-                self.hasLoadBalance = True
+                self.loadbalance = True
             sb = ClusterAwareRegex.sub('',self.originalDSN)
 
             TopologyAwareRegex = re.compile(r'topology_keys( )*=( )*(\S)*( )?')
@@ -52,7 +52,7 @@ class LoadBalanceProperties:
             propValue = backup_dict.pop('load_balance')
             propValue = propValue.lower().strip()
             if propValue == 'true':
-                self.hasLoadBalance = True
+                self.loadbalance = True
             if 'topology_keys' in backup_dict:
                 self.placements = backup_dict.pop('topology_keys')
         return backup_dict
@@ -70,8 +70,8 @@ class LoadBalanceProperties:
     def getStrippedProperties(self):
         return self.ybProperties
 
-    def hasLoadBalanced(self):
-        return self.hasLoadBalance
+    def hasLoadBalance(self):
+        return self.loadbalance
 
     def getAppropriateLoadBalancer(self):
         if self.placements == '':

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -3,6 +3,8 @@ from psycopg2.policies import ClusterAwareLoadBalancer,TopologyAwareLoadBalancer
 class LoadBalanceProperties:
 
     CONNECTION_MANAGER_MAP = {}
+    placements = ''
+    SIMPLE_LB = 'simple'
 
     def __init__(self, dsn, **kwargs):
         self.SIMPLE_LB = 'simple'

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -12,7 +12,7 @@ class LoadBalanceProperties:
         self.originalProperties = kwargs
         self.hasLoadBalance = False
         self.placements = ''
-        self.ybProperties = {}
+        self.ybProperties = self.originalProperties
         self.ybDSN = None
         if self.originalDSN != None :
             self.ybDSN = self.processURL()

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -91,7 +91,13 @@ class ClusterAwareLoadBalancer:
         
     def getPrivateOrPublicServers(self, useHostColumn, privateHosts, publicHosts):
         if useHostColumn == None :
-            return None
+            print('Either private or public should have matched with one of the servers. Using private addresses.')
+            if not publicHosts:
+                return privateHosts
+            if not privateHosts:
+                return publicHosts
+            else :
+                return None
         currentHosts = privateHosts if useHostColumn else publicHosts
         return currentHosts
 

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -1,0 +1,218 @@
+import re
+import sys
+import time
+import random
+import psycopg2
+import psycopg2.extensions
+
+
+class ClusterAwareLoadBalancer:
+
+    instance = None
+    GET_SERVERS_QUERY = "select * from yb_servers()"
+    REFRESH_LIST_SECONDS = 300
+    lastServerListFetchTime = 0
+    servers = []
+    hostToNumConnMap = {}
+    hostPortMap = {}
+    hostPortMap_public = {}
+    unreachableHosts = []
+    GET_SERVERS_QUERY = "select * from yb_servers()"
+    REFRESH_LIST_SECONDS = 30
+
+    # def __init__(self):
+    #     self.GET_SERVERS_QUERY = "select * from yb_servers()"
+    #     self.REFRESH_LIST_SECONDS = 300
+    #     self.lastServerListFetchTime = 0
+    #     self.servers = []
+    #     self.hostToNumConnMap = {}
+    #     self.hostPortMap = {}
+    #     self.hostPortMap_public = {}
+    #     self.unreachableHosts = []
+    #     self.GET_SERVERS_QUERY = "select * from yb_servers()"
+    #     self.REFRESH_LIST_SECONDS = 300
+
+    def getInstance():
+        if ClusterAwareLoadBalancer.instance == None:
+            ClusterAwareLoadBalancer.instance = ClusterAwareLoadBalancer()
+        return ClusterAwareLoadBalancer.instance
+
+    
+    def getPort(self, host):
+        port = self.hostPortMap.get(host)
+        if port == None :
+            port = self.hostPortMap_public.get(host)
+        return port
+    
+    def getLeastLoadedServer(self,failedhosts):
+        chosenHost = ''
+        minConnectionsHostList = []
+        min = sys.maxsize
+        # self.printHostToConnMap()
+        for h in self.hostToNumConnMap.keys():
+            if h in failedhosts:
+                continue
+            currLoad = self.hostToNumConnMap.get(h)
+            if currLoad < min:
+                min = currLoad
+                minConnectionsHostList.clear()
+                minConnectionsHostList.append(h)
+            elif currLoad == min :
+                minConnectionsHostList.append(h)
+        
+        if len(minConnectionsHostList) > 0 :
+            idx = random.randint(0,len(minConnectionsHostList)-1)
+            chosenHost = minConnectionsHostList[idx]
+        
+        if chosenHost != '':
+            self.updateConnectionMap(chosenHost,1)
+        
+        return chosenHost
+    
+    def needsRefresh(self):
+        currentTimeInSeconds = time.time()
+        diff = currentTimeInSeconds - self.lastServerListFetchTime
+        firstTime = not self.servers
+        # print('First time', firstTime)
+        # print('diff > self.REFRESH_LIST_SECONDS', diff > self.REFRESH_LIST_SECONDS)
+        # print('diff', diff)
+        return (firstTime or diff > self.REFRESH_LIST_SECONDS)
+
+    def getCurrentServers(self, conn):
+        cur = conn.cursor()
+        cur.execute(self.GET_SERVERS_QUERY)
+        rs = cur.fetchall()
+        currentPrivateIps = []
+        currentPublicIps = []
+        hostConnectedTo = conn.info.host_addr
+        useHostColumn = None
+        isIpv6Addresses = ':' in hostConnectedTo
+        if isIpv6Addresses:
+            hostConnectedTo = hostConnectedTo.replace('[','').replace(']','')
+        
+        for row in rs :
+            host = row[0]
+            public_host = row[7]
+            port = row[1]
+            self.hostPortMap[host] = port
+            self.hostPortMap_public[public_host] = port
+            currentPrivateIps.append(host)
+            currentPublicIps.append(public_host)
+            if useHostColumn == None :
+                if hostConnectedTo == host :
+                    useHostColumn = True
+                elif hostConnectedTo == public_host :
+                    useHostColumn = False
+        
+        return self.getPrivateOrPublicServers(useHostColumn, currentPrivateIps, currentPublicIps)
+        
+    def getPrivateOrPublicServers(self, useHostColumn, privateHosts, publicHosts):
+        if useHostColumn == None :
+            return None
+        currentHosts = privateHosts if useHostColumn else publicHosts
+        return currentHosts
+
+    def refresh(self, conn):
+        if not self.needsRefresh():
+            return True
+        # print('Refreshing server list')
+        currTime = time.time()
+        self.servers = self.getCurrentServers(conn)
+        # print(self.servers)
+        if not self.servers:
+            return False
+        self.lastServerListFetchTime = currTime
+        self.unreachableHosts.clear()
+        for h in self.servers :
+            if not h in self.hostToNumConnMap.keys():
+                self.hostToNumConnMap[h] = 0
+        return True
+
+    def getServers(self):
+        return self.servers
+
+
+    def updateConnectionMap(self, host, incDec):
+        currentCount = self.hostToNumConnMap.get(host)
+        if currentCount == 0 and incDec < 0 :
+            return
+        if currentCount == None and incDec > 0 :
+            self.hostToNumConnMap[host] = incDec
+        elif currentCount != None:
+            self.hostToNumConnMap[host] = currentCount + incDec
+
+    def getUnreachableHosts(self):
+        return self.unreachableHosts
+    
+    def updateFailedHosts(self, chosenHost):
+        self.unreachableHosts.append(chosenHost)
+        self.hostToNumConnMap.pop(chosenHost)
+
+    def loadBalancingNodes(self):
+        return 'all'
+
+    def setForRefresh(self):
+        self.lastServerListFetchTime = 0
+
+    def printHostToConnMap(self):
+        print('Current load on', self.loadBalancingNodes(),' servers')
+        print('-------------------------------------')
+        for key,value in self.hostToNumConnMap.items():
+            print(key, value)
+
+class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
+
+    def __init__(self, placementvalues):
+        self.placements = placementvalues
+        self.allowedPlacements = {}
+        self.populatePlacementMap()
+    
+    def populatePlacementMap(self):
+        placementstrings = self.placements.split(',')
+        for pl in placementstrings :
+            regionandzone = pl.split('.')
+            if len(regionandzone) == 1 :
+                self.allowedPlacements[regionandzone[1]] = []
+            else :
+                Set = self.allowedPlacements.get(regionandzone[1])
+                if Set:
+                    Set.append(regionandzone[2])
+                    self.allowedPlacements[regionandzone[1]] = Set
+                else :
+                    zoneset = []
+                    zoneset.append(regionandzone[2])
+                    self.allowedPlacements[regionandzone[1]] = zoneset
+    
+    def getCurrentServers(self, conn):
+        # print('In topology aware getCurrentServers')
+        cur = conn.cursor()
+        cur.execute(self.GET_SERVERS_QUERY)
+        rs = cur.fetchall()
+        currentPrivateIps = []
+        currentPublicIps = []
+        hostConnectedTo = conn.info.host_addr
+        useHostColumn = None
+        isIpv6Addresses = ':' in hostConnectedTo
+        if isIpv6Addresses:
+            hostConnectedTo = hostConnectedTo.replace('[','').replace(']','')
+        
+        for row in rs :
+            host = row[0]
+            public_host = row[7]
+            region = row[5]
+            zone = row[6]
+            port = row[1]
+            self.hostPortMap[host] = port
+            self.hostPortMap_public[public_host] = port
+            zones = self.allowedPlacements.get(region)
+            if useHostColumn == None :
+                if hostConnectedTo == host :
+                    useHostColumn = True
+                elif hostConnectedTo == public_host :
+                    useHostColumn = False
+            if zones != None and (len(zones) == 0 or zone in zones) :
+                currentPrivateIps.append(host)
+                currentPublicIps.append(public_host)
+        
+        return self.getPrivateOrPublicServers(useHostColumn, currentPrivateIps, currentPublicIps)
+        

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -18,19 +18,6 @@ class ClusterAwareLoadBalancer:
     hostPortMap_public = {}
     unreachableHosts = []
     GET_SERVERS_QUERY = "select * from yb_servers()"
-    REFRESH_LIST_SECONDS = 30
-
-    # def __init__(self):
-    #     self.GET_SERVERS_QUERY = "select * from yb_servers()"
-    #     self.REFRESH_LIST_SECONDS = 300
-    #     self.lastServerListFetchTime = 0
-    #     self.servers = []
-    #     self.hostToNumConnMap = {}
-    #     self.hostPortMap = {}
-    #     self.hostPortMap_public = {}
-    #     self.unreachableHosts = []
-    #     self.GET_SERVERS_QUERY = "select * from yb_servers()"
-    #     self.REFRESH_LIST_SECONDS = 300
 
     def getInstance():
         if ClusterAwareLoadBalancer.instance == None:
@@ -48,7 +35,6 @@ class ClusterAwareLoadBalancer:
         chosenHost = ''
         minConnectionsHostList = []
         min = sys.maxsize
-        # self.printHostToConnMap()
         for h in self.hostToNumConnMap.keys():
             if h in failedhosts:
                 continue
@@ -73,9 +59,6 @@ class ClusterAwareLoadBalancer:
         currentTimeInSeconds = time.time()
         diff = currentTimeInSeconds - self.lastServerListFetchTime
         firstTime = not self.servers
-        # print('First time', firstTime)
-        # print('diff > self.REFRESH_LIST_SECONDS', diff > self.REFRESH_LIST_SECONDS)
-        # print('diff', diff)
         return (firstTime or diff > self.REFRESH_LIST_SECONDS)
 
     def getCurrentServers(self, conn):
@@ -115,10 +98,8 @@ class ClusterAwareLoadBalancer:
     def refresh(self, conn):
         if not self.needsRefresh():
             return True
-        # print('Refreshing server list')
         currTime = time.time()
         self.servers = self.getCurrentServers(conn)
-        # print(self.servers)
         if not self.servers:
             return False
         self.lastServerListFetchTime = currTime
@@ -130,7 +111,6 @@ class ClusterAwareLoadBalancer:
 
     def getServers(self):
         return self.servers
-
 
     def updateConnectionMap(self, host, incDec):
         currentCount = self.hostToNumConnMap.get(host)
@@ -184,7 +164,6 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
                     self.allowedPlacements[regionandzone[1]] = zoneset
     
     def getCurrentServers(self, conn):
-        # print('In topology aware getCurrentServers')
         cur = conn.cursor()
         cur.execute(self.GET_SERVERS_QUERY)
         rs = cur.fetchall()

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -91,10 +91,9 @@ class ClusterAwareLoadBalancer:
         
     def getPrivateOrPublicServers(self, useHostColumn, privateHosts, publicHosts):
         if useHostColumn == None :
-            print('Either private or public should have matched with one of the servers. Using private addresses.')
-            if not publicHosts:
+            if privateHosts:
                 return privateHosts
-            if not privateHosts:
+            if publicHosts:
                 return publicHosts
             else :
                 return None

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -10,7 +10,7 @@ class ClusterAwareLoadBalancer:
 
     instance = None
     GET_SERVERS_QUERY = "select * from yb_servers()"
-    REFRESH_LIST_SECONDS = 30
+    REFRESH_LIST_SECONDS = 300
     lastServerListFetchTime = 0
     servers = []
     hostToNumConnMap = {}

--- a/psycopg/connection_type.c
+++ b/psycopg/connection_type.c
@@ -142,6 +142,35 @@ exit:
 static PyObject *
 psyco_conn_close(connectionObject *self, PyObject *dummy)
 {
+    /*
+    *
+    * Import the loadbalance module and get the appropriate loadbalancer
+    *
+    */
+    PyObject *m = PyImport_ImportModule("psycopg2.loadbalanceproperties");
+    PyObject *comp = PyObject_GetAttrString(m, "LoadBalanceProperties");
+    PyObject* loadbalancefunc = PyUnicode_FromString((char*)"getAppropriateLoadBalancer");
+    PyObject *loadbalancer = PyObject_CallMethodObjArgs(
+                comp, loadbalancefunc,comp, NULL);
+
+    
+    if (loadbalancer != NULL){
+        const char *val;
+        val = PQhostaddr(self->pgconn);
+        if (!val) {
+            Py_RETURN_NONE;
+        }
+        PyObject* host = conn_text_from_chars(self, val);
+        PyObject* incDec = PyInt_FromLong(-1);
+
+        /*
+        * update the connection map
+        */
+
+        PyObject* updateConnectionMap = PyUnicode_FromString((char*)"updateConnectionMap");
+        PyObject* tmp1 = PyObject_CallMethodObjArgs(
+                    loadbalancer, updateConnectionMap, host,incDec, NULL);
+    }
     Dprintf("psyco_conn_close: closing connection at %p", self);
     conn_close(self);
     Dprintf("psyco_conn_close: connection at %p closed", self);

--- a/psycopg/connection_type.c
+++ b/psycopg/connection_type.c
@@ -171,6 +171,7 @@ psyco_conn_close(connectionObject *self, PyObject *dummy)
         PyObject* tmp1 = PyObject_CallMethodObjArgs(
                     loadbalancer, updateConnectionMap, host,incDec, NULL);
     }
+    
     Dprintf("psyco_conn_close: closing connection at %p", self);
     conn_close(self);
     Dprintf("psyco_conn_close: connection at %p closed", self);

--- a/psycopg/conninfo_type.c
+++ b/psycopg/conninfo_type.c
@@ -124,6 +124,28 @@ host_get(connInfoObject *self)
     return conn_text_from_chars(self->conn, val);
 }
 
+static const char hostaddr_doc[] =
+"The server host name of the connection.\n"
+"\n"
+"This can be a host name, an IP address, or a directory path if the\n"
+"connection is via Unix socket. (The path case can be distinguished\n"
+"because it will always be an absolute path, beginning with ``/``.)\n"
+"\n"
+".. seealso:: libpq docs for `PQhostaddr()`__ for details.\n"
+".. __: https://www.postgresql.org/docs/current/static/libpq-status.html"
+    "#LIBPQ-PQHOST";
+
+static PyObject *
+hostaddr_get(connInfoObject *self)
+{
+    const char *val;
+
+    val = PQhostaddr(self->conn->pgconn);
+    if (!val) {
+        Py_RETURN_NONE;
+    }
+    return conn_text_from_chars(self->conn, val);
+}
 
 static const char port_doc[] =
 "The port of the connection.\n"
@@ -536,6 +558,7 @@ static struct PyGetSetDef connInfoObject_getsets[] = {
     { "user", (getter)user_get, NULL, (char *)user_doc },
     { "password", (getter)password_get, NULL, (char *)password_doc },
     { "host", (getter)host_get, NULL, (char *)host_doc },
+    { "host_addr", (getter)hostaddr_get, NULL, (char *)hostaddr_doc },
     { "port", (getter)port_get, NULL, (char *)port_doc },
     { "options", (getter)options_get, NULL, (char *)options_doc },
     { "dsn_parameters", (getter)dsn_parameters_get, NULL,

--- a/psycopg/conninfo_type.c
+++ b/psycopg/conninfo_type.c
@@ -125,9 +125,9 @@ host_get(connInfoObject *self)
 }
 
 static const char hostaddr_doc[] =
-"The server host name of the connection.\n"
+"The server host ip of the connection.\n"
 "\n"
-"This can be a host name, an IP address, or a directory path if the\n"
+"This can be  an IP address if the\n"
 "connection is via Unix socket. (The path case can be distinguished\n"
 "because it will always be an absolute path, beginning with ``/``.)\n"
 "\n"

--- a/psycopg2.cproj
+++ b/psycopg2.cproj
@@ -53,6 +53,8 @@
     <None Include="lib\extras.py" />
     <None Include="lib\__init__.py" />
     <None Include="lib\pool.py" />
+    <None Include="lib\policies.py" />
+    <None Include="lib\loadbalancingproperties.py" />
     <None Include="lib\tz.py" />
     <None Include="psycopg\adapter_asis.h" />
     <None Include="psycopg\adapter_binary.h" />

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 # Take a look at https://www.python.org/dev/peps/pep-0440/
 # for a consistent versioning pattern.
 
-PSYCOPG_VERSION = '2.9.3.dev0'
+PSYCOPG_VERSION = '2.9.3.post0'
 
 
 # note: if you are changing the list of supported Python version please fix
@@ -546,12 +546,12 @@ except Exception:
     print("failed to read readme: ignoring...")
     readme = __doc__
 
-setup(name="psycopg2-yb",
+setup(name="psycopg2-yugabytedb",
       version=PSYCOPG_VERSION,
-      author="Federico Di Gregorio",
-      author_email="fog@initd.org",
-      maintainer="Daniele Varrazzo",
-      maintainer_email="daniele.varrazzo@gmail.com",
+      author="Yugabyte",
+      author_email="pypi@yugabyte.com",
+      maintainer="Sfurti Sarah",
+      maintainer_email="ssarah@yugabyte.com",
       url="https://psycopg.org/",
       license="LGPL with exceptions",
       platforms=["any"],
@@ -567,7 +567,7 @@ setup(name="psycopg2-yb",
       project_urls={
           'Homepage': 'https://psycopg.org/',
           'Documentation': 'https://www.psycopg.org/docs/',
-          'Code': 'https://github.com/psycopg/psycopg2',
+          'Code': 'https://github.com/yugabyte/psycopg2',
           'Issue Tracker': 'https://github.com/psycopg/psycopg2/issues',
-          'Download': 'https://pypi.org/project/psycopg2/',
+          'Download': 'https://pypi.org/project/psycopg2-yugabytedb/',
       })

--- a/setup.py
+++ b/setup.py
@@ -546,7 +546,7 @@ except Exception:
     print("failed to read readme: ignoring...")
     readme = __doc__
 
-setup(name="PythonSmartDriver",
+setup(name="psycopg2-yb",
       version=PSYCOPG_VERSION,
       author="Federico Di Gregorio",
       author_email="fog@initd.org",

--- a/setup.py
+++ b/setup.py
@@ -546,7 +546,7 @@ except Exception:
     print("failed to read readme: ignoring...")
     readme = __doc__
 
-setup(name="psycopg2",
+setup(name="PythonSmartDriver",
       version=PSYCOPG_VERSION,
       author="Federico Di Gregorio",
       author_email="fog@initd.org",

--- a/tests/test_green.py
+++ b/tests/test_green.py
@@ -188,6 +188,7 @@ class CallbackErrorTestCase(ConnectingTestCase):
                 # the loop will be broken by a server error
                 continue
 
+    @skip_before_postgres(11, 2)
     def test_errors_on_connection(self):
         # Test error propagation in the different stages of the connection
         for i in range(100):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -86,17 +86,17 @@ class ConnectTestCase(unittest.TestCase):
         self.assertEqual(self.args[0], 'user=postgres')
         psycopg2.connect(password='secret')
         self.assertEqual(self.args[0], 'password=secret')
-        psycopg2.connect(port=5432)
-        self.assertEqual(self.args[0], 'port=5432')
+        psycopg2.connect(port=5433)
+        self.assertEqual(self.args[0], 'port=5433')
         psycopg2.connect(sslmode='require')
         self.assertEqual(self.args[0], 'sslmode=require')
 
         psycopg2.connect(database='foo',
-            user='postgres', password='secret', port=5432)
+            user='postgres', password='secret', port=5433)
         self.assert_('dbname=foo' in self.args[0])
         self.assert_('user=postgres' in self.args[0])
         self.assert_('password=secret' in self.args[0])
-        self.assert_('port=5432' in self.args[0])
+        self.assert_('port=5433' in self.args[0])
         self.assertEqual(len(self.args[0].split()), 4)
 
     def test_generic_keywords(self):


### PR DESCRIPTION
The simple load balance is disabled by default. It can be enabled using `load_balance=true` in the url.

The user can also provide topology-aware load balance property in the url as `topology_keys=<cloudname>.<regionname>.<zonename>` to connect to least loaded host (in its view) in the given availability zone.
