### PR TITLE
Add support for Fallback topology

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ The following connection properties need to be added to enable load balancing:
 
 * load_balance - enable cluster-aware load balancing by setting this property to True; disabled by default.
 * topology_keys - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as cloud.region.zone.
+* yb-servers-refresh-interval - The list of servers, to balance the connection load on, are refreshed periodically every 5 minutes by default. This time can be regulated by this property.
 
 Pass new connection properties for load balancing in the connection URL or in the dictionary. To enable uniform load balancing across all servers, you set the load-balance property to True in the URL, as per the following example.
 
@@ -116,3 +117,11 @@ Connection String::
 Connection Dictionary::
 
     conn = psycopg2.connect(user = 'username', password='xxx', host = 'hostname', port = 'port', dbname = 'database_name', load_balance='True', topology_keys='cloud1.region1.zone1,cloud2.region2.zone2')
+
+Multiple topologies can also be passed to the Topology Keys property, and each of them can also be given a preference value, as per the following example.::
+
+    conn = psycopg2.connect("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=cloud1.region1.zone1:1,cloud2.region2.zone2:2")
+
+The preference value (appended after :) is optional. So it is compatible with previous syntax of specifying cloud placements.
+
+Preference value :1 means primary placement zone(s), value :2 means first fallback, value :3 means second fallback and so on.

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -155,16 +155,15 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             controlConnection.cursor_factory = cursor_factory
         if not loadbalancer.refresh(controlConnection):
             return None
-        if needsRefresh:
+        if chosenHost != '':
             dsnhost = controlConnection.info.host_addr
-            print("dsn Host", dsnhost)
             loadbalancer.updateConnectionMap(dsnhost, 1)
             loadbalancer.updateConnectionMap(chosenHost, -1)
         
         try:
             controlConnection.close()
-        except Exception:
-            print("Could not close control connection")
+        except Exception as e:
+            print("Could not close control connection:", str(e))
 
         # Getting chosenHost again after refresh for the latest least loaded server
         
@@ -175,7 +174,6 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
     
     while chosenHost != '':
         try :
-            print("Chosen host:", chosenHost)
             dsn = getDSNWithChosenHost(loadbalancer,dsn,chosenHost)
             newconn = _connect(dsn, connection_factory=connection_factory, **kwasync)
             if cursor_factory is not None:

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -157,9 +157,14 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             return None
         if needsRefresh:
             dsnhost = controlConnection.info.host_addr
+            print("dsn Host", dsnhost)
             loadbalancer.updateConnectionMap(dsnhost, 1)
             loadbalancer.updateConnectionMap(chosenHost, -1)
-        controlConnection.close()
+        
+        try:
+            controlConnection.close()
+        except Exception:
+            print("Could not close control connection")
 
         # Getting chosenHost again after refresh for the latest least loaded server
         
@@ -170,6 +175,7 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
     
     while chosenHost != '':
         try :
+            print("Chosen host:", chosenHost)
             dsn = getDSNWithChosenHost(loadbalancer,dsn,chosenHost)
             newconn = _connect(dsn, connection_factory=connection_factory, **kwasync)
             if cursor_factory is not None:

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -185,7 +185,7 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             else:
                 return newconn
         except OperationalError:
-            print('Couldnt connect to ', chosenHost, ' adding to failed list')
+            print('Couldn\'t connect to ', chosenHost, ' adding to failed list')
             failedHosts.append(chosenHost)
             loadbalancer.updateFailedHosts(chosenHost)
             try :

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -90,7 +90,7 @@ class LoadBalanceProperties:
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
             if ld == None:
                 # print("Refresh Interval", self.EQUALS)
-                ld = ClusterAwareLoadBalancer.getInstance(300)
+                ld = ClusterAwareLoadBalancer.getInstance(self.refreshInterval)
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
         else:
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.placements)

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -14,6 +14,7 @@ class LoadBalanceProperties:
         self.originalProperties = kwargs
         self.loadbalance = False
         self.placements = ''
+        self.refreshInterval = -1
         self.ybProperties = self.originalProperties
         self.ybDSN = None
         if self.originalDSN != None :
@@ -44,6 +45,15 @@ class LoadBalanceProperties:
                 tp_parts = list(filter(('').__ne__, tp_parts))
                 self.placements = tp_parts[1].strip()
                 sb = TopologyAwareRegex.sub('',sb)
+
+            RefreshIntervalRegex = re.compile(r'yb-servers-refresh-interval( )*=( )*[0-9]*( )?')
+            ri_string = RefreshIntervalRegex.search(self.originalDSN)
+            if ri_string != None:
+                ri_string = ri_string.group()
+                ri_parts = ri_string.split(self.EQUALS)
+                ri_parts = list(filter(('').__ne__, ri_parts))
+                self.refreshInterval = int(ri_parts[1].strip())
+                sb = RefreshIntervalRegex.sub('', sb)
         return sb
         
     def processProperties(self):
@@ -55,6 +65,8 @@ class LoadBalanceProperties:
                 self.loadbalance = True
             if 'topology_keys' in backup_dict:
                 self.placements = backup_dict.pop('topology_keys')
+            if 'yb-servers-refresh-interval' in backup_dict:
+                self.refreshInterval = int(backup_dict.pop('yb-servers-refresh-interval'))
         return backup_dict
 
 
@@ -77,7 +89,7 @@ class LoadBalanceProperties:
         if self.placements == '':
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
             if ld == None:
-                ld = ClusterAwareLoadBalancer.getInstance()
+                ld = ClusterAwareLoadBalancer.getInstance(self.refreshInterval)
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
         else:
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.placements)

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -90,7 +90,6 @@ class LoadBalanceProperties:
         if self.placements == '':
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
             if ld == None:
-                # print("Refresh Interval", self.EQUALS)
                 ld = ClusterAwareLoadBalancer.getInstance(self.refreshInterval)
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
         else:

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -89,7 +89,8 @@ class LoadBalanceProperties:
         if self.placements == '':
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
             if ld == None:
-                ld = ClusterAwareLoadBalancer.getInstance(self.refreshInterval)
+                # print("Refresh Interval", self.EQUALS)
+                ld = ClusterAwareLoadBalancer.getInstance(300)
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
         else:
             ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.placements)

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -5,6 +5,7 @@ class LoadBalanceProperties:
     CONNECTION_MANAGER_MAP = {}
     placements = ''
     SIMPLE_LB = 'simple'
+    refreshInterval = -1
 
     def __init__(self, dsn, **kwargs):
         self.SIMPLE_LB = 'simple'

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -45,8 +45,7 @@ class ClusterAwareLoadBalancer:
             self.servers = self.getPrivateOrPublicServers(self.useHostColumn, privatehosts, self.currentPublicIps)
             if self.servers != None and self.servers.count != 0 :
                 for h in self.servers:
-                    if not h in self.hostToNumConnMap.keys():
-                        self.hostToNumConnMap[h] = 0
+                    self.hostToNumConnMap[h] = 0
             else:
                 return '' 
         chosenHost = ''

--- a/tests/test_fallback_topology.py
+++ b/tests/test_fallback_topology.py
@@ -1,11 +1,28 @@
 import psycopg2
 from urllib.request import urlopen
 import json
+import os
 
 numConnections = 12
 url1 = "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys="
+yb_path = ""
+def createCluster():
+    global yb_path
+    yb_path = os.getenv('YB_PATH')
+    os.system(yb_path+'/bin/yb-ctl destroy')
+    os.system(yb_path+'/bin/yb-ctl create --rf 3 --placement_info \"aws.us-west.us-west-2a,aws.us-west.us-west-2b,aws.us-west.us-west-2c\"')
 
-def createConnections(url, tkValue, cnt1, cnt2, cnt3):
+def createClusterWithSixNodes():
+    global yb_path
+    yb_path = os.getenv('YB_PATH')
+    os.system(yb_path+'/bin/yb-ctl destroy')
+    os.system(yb_path+'/bin/yb-ctl create --rf 3 --placement_info \"aws.us-west.us-west-1a\" --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"')
+    os.system(yb_path + '/bin/yb-ctl add_node --placement_info \"aws.us-west.us-east-2a\"')
+    os.system(yb_path + '/bin/yb-ctl add_node --placement_info \"aws.us-west.us-east-2b\"')
+    os.system(yb_path + '/bin/yb-ctl add_node --placement_info \"aws.us-west.us-east-2c\"')
+
+
+def createConnections(url, tkValue, counts):
     connections = []
     final_url = url + tkValue
     for i in range(numConnections):
@@ -14,9 +31,13 @@ def createConnections(url, tkValue, cnt1, cnt2, cnt3):
     
     print(f"Created {numConnections} connections")
 
-    verifyOn('127.0.0.1', cnt1)
-    verifyOn('127.0.0.2', cnt2)
-    verifyOn('127.0.0.3', cnt3)
+    j = 1
+    for count in counts:
+        if count != -1 :
+            host = '127.0.0.' + str(j)
+            verifyOn(host, count)
+        
+        j = j + 1
 
     for conn1 in connections:
         conn1.close()
@@ -35,23 +56,39 @@ def verifyOn(server, expectedCount):
 
 def main():
 
+    createCluster()
+
     # All valid/available placement zones
 
-    createConnections(url1,"aws.us-west.us-west-2a,aws.us-west.us-west-2c",6,0,6)
-    createConnections(url1,"aws.us-west.us-west-2a,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2",6,6,0)
-    createConnections(url1,"aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",12,0,0)
-    createConnections(url1, "aws.us-west.*,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2", 4, 4, 4)
-    createConnections(url1, "aws.us-west.*:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3", 4, 4, 4)
+    createConnections(url1,"aws.us-west.us-west-2a,aws.us-west.us-west-2c",[6,0,6])
+    createConnections(url1,"aws.us-west.us-west-2a,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2",[6,6,0])
+    createConnections(url1,"aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",[12,0,0])
+    createConnections(url1, "aws.us-west.*,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2", [4, 4, 4])
+    createConnections(url1, "aws.us-west.*:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3", [4, 4, 4])
 
     # Some Invalid Connections
 
-    createConnections(url1, "BAD.BAD.BAD:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3", 0, 12, 0)
-    createConnections(url1, "aws.us-west.us-west-2a:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", 12, 0, 0)
-    createConnections(url1, "aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,BAD.BAD.BAD:3", 12, 0, 0)
-    createConnections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", 0, 0, 12)
-    createConnections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.*:3", 4, 4, 4) 
+    createConnections(url1, "BAD.BAD.BAD:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3", [0, 12, 0])
+    createConnections(url1, "aws.us-west.us-west-2a:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", [12, 0, 0])
+    createConnections(url1, "aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,BAD.BAD.BAD:3", [12, 0, 0])
+    createConnections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", [0, 0, 12])
+    createConnections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.*:3", [4, 4, 4]) 
     
     print("Test Passed")
 
+def checkNodeDownBehaviour():
+    # Start RF=3 cluster with 6 nodes and with placements (127.0.0.1, 127.0.0.2, 127.0.0.3) -> us-west-1a,
+    # and 127.0.0.4 -> us-east-2a, 127.0.0.5 -> us-east-2b and 127.0.0.6 -> us-east-2c
+    createClusterWithSixNodes()
+    url = "host=127.0.0.4 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys="
+    createConnections(url,'aws.us-west.us-west-1a',[4,4,4])
+
+    os.system(yb_path+"/bin/yb-ctl stop_node 1")
+    os.system(yb_path+"/bin/yb-ctl stop_node 2")
+    os.system(yb_path+"/bin/yb-ctl stop_node 3")
+
+    createConnections(url,"aws.us-west.us-west-1a", [-1, -1, -1, 4, 4, 4])
+
 if __name__ == "__main__":
     main()
+    checkNodeDownBehaviour()

--- a/tests/test_fallback_topology.py
+++ b/tests/test_fallback_topology.py
@@ -16,7 +16,7 @@ def createClusterWithSixNodes():
     global yb_path
     yb_path = os.getenv('YB_PATH')
     os.system(yb_path+'/bin/yb-ctl destroy')
-    os.system(yb_path+'/bin/yb-ctl create --rf 3 --placement_info \"aws.us-west.us-west-1a\" --tserver_flags \"placement_uuid=live,max_stale_read_bound_time_ms=60000000\"')
+    os.system(yb_path+'/bin/yb-ctl create --rf 3 --placement_info \"aws.us-west.us-west-1a\"')
     os.system(yb_path + '/bin/yb-ctl add_node --placement_info \"aws.us-west.us-east-2a\"')
     os.system(yb_path + '/bin/yb-ctl add_node --placement_info \"aws.us-west.us-east-2b\"')
     os.system(yb_path + '/bin/yb-ctl add_node --placement_info \"aws.us-west.us-east-2c\"')
@@ -88,6 +88,7 @@ def checkNodeDownBehaviour():
     os.system(yb_path+"/bin/yb-ctl stop_node 3")
 
     createConnections(url,"aws.us-west.us-west-1a", [-1, -1, -1, 4, 4, 4])
+    createConnections(url, "aws.us-west.*:1,aws.us-west.us-east-2a:2,aws.us-west.us-east-2b:2,aws.us-west.us-east-2c:3", [-1.-1,-1,6,6,0])
 
 if __name__ == "__main__":
     main()

--- a/tests/test_fallback_topology.py
+++ b/tests/test_fallback_topology.py
@@ -3,6 +3,7 @@ from urllib.request import urlopen
 import json
 
 numConnections = 12
+url1 = "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys="
 
 def createConnections(url, tkValue, cnt1, cnt2, cnt3):
     connections = []
@@ -30,14 +31,25 @@ def verifyOn(server, expectedCount):
         if connection["backend_type"] == "client backend":
             count = count + 1
     print(f"{server}:{count}")
-    # assert count == expectedCount
+    assert count == expectedCount
 
 def main():
-    createConnections("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=","aws.us-west.us-west-2a,aws.us-west.us-west-2c",6,0,6)
-    createConnections("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=","aws.us-west.us-west-2a,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2",6,6,0)
-    # createConnections("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=","aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",12,0,0)
-    
-    
+
+    # All valid/available placement zones
+
+    createConnections(url1,"aws.us-west.us-west-2a,aws.us-west.us-west-2c",6,0,6)
+    createConnections(url1,"aws.us-west.us-west-2a,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2",6,6,0)
+    createConnections(url1,"aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",12,0,0)
+    createConnections(url1, "aws.us-west.*,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2", 4, 4, 4)
+    createConnections(url1, "aws.us-west.*:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3", 4, 4, 4)
+
+    # Some Invalid Connections
+
+    createConnections(url1, "BAD.BAD.BAD:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3", 0, 12, 0)
+    createConnections(url1, "aws.us-west.us-west-2a:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", 12, 0, 0)
+    createConnections(url1, "aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,BAD.BAD.BAD:3", 12, 0, 0)
+    createConnections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", 0, 0, 12)
+    createConnections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.*:3", 4, 4, 4) 
     
     print("Test Passed")
 

--- a/tests/test_fallback_topology.py
+++ b/tests/test_fallback_topology.py
@@ -1,0 +1,45 @@
+import psycopg2
+from urllib.request import urlopen
+import json
+
+numConnections = 12
+
+def createConnections(url, tkValue, cnt1, cnt2, cnt3):
+    connections = []
+    final_url = url + tkValue
+    for i in range(numConnections):
+        conn  = psycopg2.connect(final_url)
+        connections.append(conn)
+    
+    print(f"Created {numConnections} connections")
+
+    verifyOn('127.0.0.1', cnt1)
+    verifyOn('127.0.0.2', cnt2)
+    verifyOn('127.0.0.3', cnt3)
+
+    for conn1 in connections:
+        conn1.close()
+
+
+def verifyOn(server, expectedCount):
+    count = 0
+    url = "http://" + server + ":13000/rpcz"
+    response = urlopen(url)
+    data_json = json.loads(response.read())
+    for connection in data_json["connections"]:
+        if connection["backend_type"] == "client backend":
+            count = count + 1
+    print(f"{server}:{count}")
+    # assert count == expectedCount
+
+def main():
+    createConnections("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=","aws.us-west.us-west-2a,aws.us-west.us-west-2c",6,0,6)
+    createConnections("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=","aws.us-west.us-west-2a,aws.us-west.us-west-2b:1,aws.us-west.us-west-2c:2",6,6,0)
+    # createConnections("host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=","aws.us-west.us-west-2a:1,aws.us-west.us-west-2b:2,aws.us-west.us-west-2c:3",12,0,0)
+    
+    
+    
+    print("Test Passed")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Changes:
- Added support for fallback options for the topology-aware load balancing.

```
  host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys=cloud1.region1.zone1:1,cloud1.region1.zone3:2
```
- The preference value (appended after `:`) is optional. So it is compatible with previous syntax of specifying cloud placements.
- Preference value `:1` means primary placement zone(s), value `:2` means first fallback, value `:3` means second fallback  and so on.
- Added a property `yb-servers-refresh-interval` to set the refresh interval time in seconds for fetching info from `yb_servers()` function.
- Added a test `test_fallback_topology.py` for the feature.