### PR TITLE
Add support for Connection URI format in connection string

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -132,6 +132,7 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
             return conn
         print('Failed to apply load balancing, Trying normal connection')
     
+    print("No load Balance specified")
     dsn = lbprops.getStrippedDSN()
     kwargs = lbprops.getStrippedProperties()
     dsn = _ext.make_dsn(dsn, **kwargs)
@@ -192,6 +193,21 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
     
 def getDSNWithChosenHost(loadbalancer, dsn, chosenHost):
     port = loadbalancer.getPort(chosenHost)
+    """
+    Special case for connection URI
+    """
+    if 'postgresql://' in dsn or 'postgres://' in dsn:
+        if '@' in dsn :
+            host_parameter = '@' + chosenHost + ':' + str(port) + '/'
+            HostRegex = re.compile(r'@([^/]*)/')
+            dsn = HostRegex.sub(host_parameter, dsn)
+            return dsn
+        else :
+            host_parameter = '://' + chosenHost + ':' + str(port) + '/'
+            HostRegex = re.compile(r'://([^/]*)/')
+            dsn = HostRegex.sub(host_parameter, dsn)
+            return dsn
+
     host_parameter = 'host=' + chosenHost + ' '
     port_parameter = 'port=' + str(port) + ' '
     HostRegex = re.compile(r'host( )*=( )*(\S)*( )?')

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -132,7 +132,6 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
             return conn
         print('Failed to apply load balancing, Trying normal connection')
     
-    print("No load Balance specified")
     dsn = lbprops.getStrippedDSN()
     kwargs = lbprops.getStrippedProperties()
     dsn = _ext.make_dsn(dsn, **kwargs)

--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -143,11 +143,29 @@ def make_dsn(dsn=None, **kwargs):
     # If no kwarg is specified don't mung the dsn, but verify it
     if not kwargs:
         if not 'port' in dsn:
-            dsn += ' port=5433' 
+            if 'postgresql://'  in dsn or 'postgres://'  in dsn:
+                if '@' in dsn :
+                    idx1 = dsn.index('@')
+                    idx2 = dsn.find('/', idx1)
+                    idx3  = dsn.find(':', idx1)
+                    if idx3 == -1 :
+                        res = dsn[idx1 + len('@') : idx2]
+                        newres = res + ':5433'
+                        dsn = dsn.replace(res,newres)
+                else :
+                    idx1 = dsn.index('://')
+                    idx2 = dsn.find('/', idx1 + len('://'))
+                    idx3  = dsn.find(':', idx1 + len('://'))
+                    if idx3 == -1 :
+                        res = dsn[idx1 + len('://') : idx2]
+                        newres = res + ':5433'
+                        dsn = dsn.replace(res,newres)
+            else: 
+                dsn += ' port=5433' 
         parse_dsn(dsn)
         return dsn
     
-    #Set Default pot to 5433 if not specified
+    #Set Default port to 5433 if not specified
     if not 'port' in kwargs:
         kwargs['port'] = 5433
     # Override the dsn with the parameters

--- a/lib/extensions.py
+++ b/lib/extensions.py
@@ -142,6 +142,7 @@ def make_dsn(dsn=None, **kwargs):
 
     # If no kwarg is specified don't mung the dsn, but verify it
     if not kwargs:
+        # If port is not specified make 5433 the default port
         if not 'port' in dsn:
             if 'postgresql://'  in dsn or 'postgres://'  in dsn:
                 if '@' in dsn :


### PR DESCRIPTION
The upstream psycopg2 driver supports connection using URI. URI is of the format:
```
postgresql://user:password@host:port/dbname?load_balance=True
```
Other acceptable URI formats:
```
postgresql://localhost:5433
postgresql://localhost/mydb
postgresql://user@localhost
postgresql://user:secret@localhost
postgresql://other@localhost/otherdb?connect_timeout=10&application_name=myapp
```

Adding support for all the above patterns.