### PR TITLE
Change public IPs from dict type to list type

### DIFF
--- a/lib/policies.py
+++ b/lib/policies.py
@@ -239,7 +239,7 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
         self.hostToPriorityMap = {}
         self.hostPortMap = {}
         self.hostPortMap_public = {}
-        self.currentPublicIps = {}
+        self.currentPublicIps = []
         self.placements = placementvalues
         self.allowedPlacements = {}
         self.fallbackPrivateIPs = {}

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 # Take a look at https://www.python.org/dev/peps/pep-0440/
 # for a consistent versioning pattern.
 
-PSYCOPG_VERSION = '2.9.3.1'
+PSYCOPG_VERSION = '2.9.3.2'
 
 
 # note: if you are changing the list of supported Python version please fix


### PR DESCRIPTION
The connection fails when topology keys are specified and public IPs are present in the yb_servers() function with the error: `AttributeError: 'dict' object has no attribute 'append'`. This PR fixes that bug.

Tests run for this change:
Started a cluster with yugabytedb with public_ip columns populated and checked connection with topology keys
Driver Examples repo tests