### PR TITLE
Bug fixes

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -135,7 +135,7 @@ def connect(dsn=None, connection_factory=None, cursor_factory=None, **kwargs):
     dsn = lbprops.getStrippedDSN()
     kwargs = lbprops.getStrippedProperties()
     dsn = _ext.make_dsn(dsn, **kwargs)
-    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+    conn = _connect(dsn, 'none', connection_factory=connection_factory, **kwasync)
     if cursor_factory is not None:
         conn.cursor_factory = cursor_factory
     return conn
@@ -150,14 +150,12 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
     dsn = _ext.make_dsn(dsn,**kwargs)
     needsRefresh = loadbalancer.needsRefresh()
     if chosenHost == '' or needsRefresh:
-        controlConnection = _connect(dsn, connection_factory=connection_factory, **kwasync)
+        controlConnection = _connect(dsn, 'none', connection_factory=connection_factory, **kwasync)
         if cursor_factory is not None:
             controlConnection.cursor_factory = cursor_factory
         if not loadbalancer.refresh(controlConnection):
             return None
         if chosenHost != '':
-            dsnhost = controlConnection.info.host_addr
-            loadbalancer.updateConnectionMap(dsnhost, 1)
             loadbalancer.updateConnectionMap(chosenHost, -1)
         
         try:
@@ -167,6 +165,8 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
 
         # Getting chosenHost again after refresh for the latest least loaded server
         
+        unreachableHosts = loadbalancer.getUnreachableHosts()
+        failedHosts = unreachableHosts
         chosenHost = loadbalancer.getLeastLoadedServer(failedHosts)
     
     if chosenHost == '':
@@ -175,7 +175,7 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
     while chosenHost != '':
         try :
             dsn = getDSNWithChosenHost(loadbalancer,dsn,chosenHost)
-            newconn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+            newconn = _connect(dsn, lbprops.getKey(), connection_factory=connection_factory, **kwasync)
             if cursor_factory is not None:
                 newconn.cursor_factory = cursor_factory
             if not loadbalancer.refresh(newconn):
@@ -185,10 +185,9 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             else:
                 better_node_available = loadbalancer.hasMorePreferredNodes(chosenHost)
                 if better_node_available:
-                    print('A higher level node is available')
+                    print('A higher level node is available then current host: ' + chosenHost)
                     loadbalancer.decrementHostToNumConnCount(chosenHost)
                     newconn.close()
-                    loadbalancer.has_better_node = False
                     return getConnectionBalanced(lbprops, connection_factory, cursor_factory, **kwasync)
                 return newconn
         except OperationalError:

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -185,7 +185,7 @@ def getConnectionBalanced(lbprops, connection_factory, cursor_factory=None, **kw
             else:
                 better_node_available = loadbalancer.hasMorePreferredNodes(chosenHost)
                 if better_node_available:
-                    print('A higher level node is available then current host: ' + chosenHost)
+                    print('A higher-level node is available than the current chosenHost: ' + chosenHost)
                     loadbalancer.decrementHostToNumConnCount(chosenHost)
                     newconn.close()
                     return getConnectionBalanced(lbprops, connection_factory, cursor_factory, **kwasync)

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -109,6 +109,7 @@ class ClusterAwareLoadBalancer:
             hostConnectedTo = hostConnectedTo.replace('[','').replace(']','')
 
         self.hostToPriorityMap.clear()
+        self.currentPublicIps.clear()
 
         for row in rs :
             host = row[0]
@@ -200,6 +201,7 @@ class ClusterAwareLoadBalancer:
 
     def updatePriorityMap(self, host, cloud, region, zone):
         return
+    
     def hasMorePreferredNodes(self, chosenHost):
         return False
 
@@ -299,7 +301,10 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
         isIpv6Addresses = ':' in hostConnectedTo
         if isIpv6Addresses:
             hostConnectedTo = hostConnectedTo.replace('[','').replace(']','')
+
         self.hostToPriorityMap.clear()
+        self.currentPublicIps.clear()
+
         for row in rs :
             host = row[0]
             public_host = row[7]

--- a/psycopg/connection.h
+++ b/psycopg/connection.h
@@ -88,6 +88,7 @@ struct connectionObject {
     pthread_mutex_t lock;   /* the global connection lock */
 
     char *dsn;              /* data source name */
+    char *lb_key;           /* key to get load balancer instance */
     char *error;            /* temporarily stored error before raising */
     char *encoding;         /* current backend encoding */
 

--- a/psycopg/psycopgmodule.c
+++ b/psycopg/psycopgmodule.c
@@ -75,7 +75,7 @@ HIDDEN PyObject *psyco_null = NULL;
 
 /** connect module-level function **/
 #define psyco_connect_doc \
-"_connect(dsn, [connection_factory], [async]) -- New database connection.\n\n"
+"_connect(dsn, lb_key, [connection_factory], [async]) -- New database connection.\n\n"
 
 static PyObject *
 psyco_connect(PyObject *self, PyObject *args, PyObject *keywds)
@@ -83,12 +83,13 @@ psyco_connect(PyObject *self, PyObject *args, PyObject *keywds)
     PyObject *conn = NULL;
     PyObject *factory = NULL;
     const char *dsn = NULL;
+    const char *lb_key = NULL;
     int async = 0, async_ = 0;
 
-    static char *kwlist[] = {"dsn", "connection_factory", "async", "async_", NULL};
+    static char *kwlist[] = {"dsn", "lb_key", "connection_factory", "async", "async_", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|Oii", kwlist,
-            &dsn, &factory, &async, &async_)) {
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ss|Oii", kwlist,
+            &dsn, &lb_key, &factory, &async, &async_)) {
         return NULL;
     }
 
@@ -109,9 +110,9 @@ psyco_connect(PyObject *self, PyObject *args, PyObject *keywds)
      * to further subclass) Another dsn parameter (but is not really
      * a connection parameter that can be configured) */
     if (!async) {
-        conn = PyObject_CallFunction(factory, "s", dsn);
+        conn = PyObject_CallFunction(factory, "ss", dsn, lb_key);
     } else {
-        conn = PyObject_CallFunction(factory, "si", dsn, async);
+        conn = PyObject_CallFunction(factory, "ssi", dsn, lb_key, async);
     }
 
     return conn;

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 # Take a look at https://www.python.org/dev/peps/pep-0440/
 # for a consistent versioning pattern.
 
-PSYCOPG_VERSION = '2.9.3.2'
+PSYCOPG_VERSION = '2.9.3.3'
 
 
 # note: if you are changing the list of supported Python version please fix

--- a/tests/test_fallback_topology.py
+++ b/tests/test_fallback_topology.py
@@ -5,10 +5,13 @@ from urllib.request import urlopen
 import json
 import os
 from psycopg2 import ClusterAwareLoadBalancer as _lb
+from psycopg2.loadbalanceproperties import LoadBalanceProperties
 
 num_connections = 12
+control_host = '127.0.0.1'
 url1 = "host=127.0.0.1 port=5433 user=yugabyte dbname=yugabyte load_balance=True topology_keys="
 yb_path = ""
+
 def create_cluster():
     global yb_path
     yb_path = os.getenv('YB_PATH')
@@ -41,24 +44,71 @@ def create_connections(url, tkValue, counts):
             verifyOn(host, count)
         
         j = j + 1
+    
+    verifyLocalConnections(counts, tkValue, 1)
 
     for conn1 in connections:
         conn1.close()
+    
+    time.sleep(5)
+    
+    verifyLocalConnections(counts, tkValue, 0)
 
+def verifyLocalConnections(counts, key, k):
+    
+    try:
+        if key not in LoadBalanceProperties.CONNECTION_MANAGER_MAP:
+            raise Exception("Error: Load Balancer instance not found in CONNECTION_MANAGER_MAP")
+        
+        load_balance_instance = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(key)
+        expected_counts = load_balance_instance.hostToNumConnMap
+
+        j = 1
+        for count in counts:
+            if count != -1 and count != 0:
+                host = '127.0.0.' + str(j)
+                if host in expected_counts:
+                    if expected_counts.get(host) != count * k:
+                        raise Exception("host: " + host + " expected Count in hostToNumConnMap: "+ str(count) + " actualCount: " + str(expected_counts.get(host)))
+                else:
+                    raise Exception("host: " + host + " not found in hostToNumConnMap")
+            j = j + 1
+
+    except Exception as ex:
+        print(expected_counts)
+        print(f'{ex}')
+        exit(1)
 
 def verifyOn(server, expectedCount):
     count = 0
     url = "http://" + server + ":13000/rpcz"
     try:
-        response = urlopen(url)
+        try:
+            response = urlopen(url)
+        except Exception as ex:
+            if expectedCount != 0:
+                print("error opening " + url)
+                print(f'{ex}')
+                exit(1)
+            else:
+                # Node is expected to be down
+                return
         data_json = json.loads(response.read())
         for connection in data_json["connections"]:
             if connection["backend_type"] == "client backend":
                 count = count + 1
         print(f"{server}:{count}")
-        assert count == expectedCount
+        if not count == expectedCount:
+            # Control connection close() can fail sometimes
+            if server == control_host:
+                if not count == (expectedCount + 1):
+                    raise Exception("host: " + server + " Expected Count: "+ str(expectedCount) + " actualCount: " + str(count))
+            else:
+                raise Exception("host: " + server + " Expected Count: "+ str(expectedCount) + " actualCount: " + str(count))
     except Exception as ex:
         print(f'{ex}')
+        exit(1)
+
 def main():
 
     create_cluster()
@@ -81,12 +131,13 @@ def main():
     create_connections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.us-west-2c:3", [0, 0, 12])
     create_connections(url1, "BAD.BAD.BAD:1,BAD.BAD.BAD:2,aws.us-west.*:3", [4, 4, 4])
     
-    print("Test Passed")
+    print("Test 1 Passed")
 
 def check_node_down_behaviour():
     # Start RF=3 cluster with 6 nodes and with placements (127.0.0.1, 127.0.0.2, 127.0.0.3) -> us-west-1a,
     # and 127.0.0.4 -> us-east-2a, 127.0.0.5 -> us-east-2b and 127.0.0.6 -> us-east-2c
     create_cluster_with_six_nodes()
+    control_host = '127.0.0.4'
     url = "host=127.0.0.4 port=5433 user=yugabyte dbname=yugabyte yb_servers_refresh_interval=10 load_balance=True topology_keys="
     create_connections(url, 'aws.us-west.us-west-1a', [4, 4, 4])
 
@@ -97,7 +148,9 @@ def check_node_down_behaviour():
     # time.sleep(15)
 
     create_connections(url, "aws.us-west.us-west-1a", [-1, -1, -1, 4, 4, 4])
-    create_connections(url, "aws.us-west.*:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:2,aws.us-east.us-east-2c:3", [-1. - 1, -1, 6, 6, 0])
+    create_connections(url, "aws.us-west.*:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:2,aws.us-east.us-east-2c:3", [-1, -1, -1, 6, 6, 0])
+
+    print("Test 2 Passed")
 
 def check_node_up_behaviour():
     # Start RF=3 cluster with 6 nodes
@@ -107,6 +160,7 @@ def check_node_up_behaviour():
     # 127.0.0.5 -> us-east-2b
     # 127.0.0.6 -> us-east-2c
     create_cluster_with_six_nodes()
+    control_host = '127.0.0.4'
     url = "host=127.0.0.4,127.0.0.5 port=5433 user=yugabyte dbname=yugabyte yb_servers_refresh_interval=10 load_balance=True topology_keys="
     create_connections(url, "aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4",[4, 4, 4, 0, 0, 0])
 
@@ -114,11 +168,12 @@ def check_node_up_behaviour():
     os.system(yb_path + "/bin/yb-ctl stop_node 2")
     os.system(yb_path + "/bin/yb-ctl stop_node 3")
     os.system(yb_path + "/bin/yb-ctl stop_node 4")
+    control_host = '127.0.0.5'
 
     create_connections(url, "aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4",[-1, -1, -1, -1, 12, 0])
 
     os.system(yb_path + "/bin/yb-ctl start_node 4 --placement_info \"aws.us-east.us-east-2a\"")
-
+    control_host = '127.0.0.4'
     time.sleep(15)
 
     create_connections(url, "aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4",[-1, -1, -1, 12, 0, 0])
@@ -129,6 +184,8 @@ def check_node_up_behaviour():
     time.sleep(15)
 
     create_connections(url, "aws.us-west.us-west-1a:1,aws.us-east.us-east-2a:2,aws.us-east.us-east-2b:3,aws.us-east.us-east-2c:4",[6, 6, -1, 0, 0, 0])
+
+    print("Test 3 Passed")
 
 
 


### PR DESCRIPTION
This PR includes fix for the following bugs:

- For `TopologyAwareLoadBalancing` the default value of `yb-servers-refresh-interval` and `failed-hosts-ttl-seconds` was -1 for both instead of 300 and 5 respectively.
- On closing the connections using `connection.close()`, the correct instance of the load balancer was not being returned due to which the connection count was not decreasing in `hostToNumConnMap`
- Not updating the `failedHot` list after refresh in `getConnectionBalanced()`, causing incorrect balancing of connections.