### PR TITLE
Read Replica cluster support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ The following connection properties need to be added to enable load balancing:
 
 * load_balance - enable cluster-aware load balancing by setting this property to true or any; disabled by default. `This section`_ explains the different values for `load_balance` parameter.
 * topology_keys - provide comma-separated geo-location values to enable topology-aware load balancing. Geo-locations can be provided as cloud.region.zone.
-* yb_servers_refresh_interval - The list of servers, to balance the connection load on, are refreshed periodically every 5 minutes by default. This time can be regulated by this property.
+* yb_servers_refresh_interval - The list of servers, to balance the connection load on, is refreshed periodically every 5 minutes by default. This time can be regulated by this property.
 
 .. _`This section`: #read-replica-cluster
 

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -4,17 +4,16 @@ class LoadBalanceProperties:
 
     CONNECTION_MANAGER_MAP = {}
     placements = ''
-    SIMPLE_LB = 'simple'
     refreshInterval = 300
     failed_host_ttl_seconds = 5
+    fallback_to_topology_keys_only = False
 
     def __init__(self, dsn, **kwargs):
-        self.SIMPLE_LB = 'simple'
         self.LOAD_BALANCE_PROPERTY_KEY = 'load_balance'
         self.EQUALS = '='
         self.originalDSN = dsn
         self.originalProperties = kwargs
-        self.loadbalance = False
+        self.loadbalance = 'false'
         self.placements = ''
         self.key = ''
         self.refreshInterval = 300
@@ -27,7 +26,7 @@ class LoadBalanceProperties:
         
 
     def processURL(self):
-        ClusterAwareRegex = re.compile(r'load_balance( )*=( )*([a-z]*[A-Z]*)*( )?')
+        ClusterAwareRegex = re.compile(r'load_balance( )*=( )*([a-z]*[A-Z]*)*-?([a-z]*[A-Z]*)*( )?')
         lb_string = ClusterAwareRegex.search(self.originalDSN)
         if lb_string == None :
             return self.originalDSN
@@ -36,8 +35,10 @@ class LoadBalanceProperties:
             lb_parts = lb_string.split(self.EQUALS)
             lb_parts = list(filter(('').__ne__, lb_parts))
             propValue = lb_parts[1].lower().strip()
-            if propValue == 'true':
-                self.loadbalance = True
+            if (propValue == 'true' or propValue == 'any' or propValue == 'only-rr' or propValue == 'only-primary' or propValue == 'prefer-rr' or propValue == 'prefer-primary' or propValue == 'false'):
+                self.loadbalance = propValue
+            else : 
+                raise ValueError('invalid load_balance value: Valid values are only-rr, only-primary, prefer-rr, prefer-primary, any or true')
             sb = ClusterAwareRegex.sub('',self.originalDSN)
 
             TopologyAwareRegex = re.compile(r'topology_keys( )*=( )*(\S)*( )?')
@@ -66,6 +67,17 @@ class LoadBalanceProperties:
                 ri_parts = list(filter(('').__ne__, ri_parts))
                 self.failed_host_ttl_seconds = int(ri_parts[1].strip())
                 sb = FailedHostTTLRegex.sub('', sb)
+                
+            FallbackToTopologyKeysOnlyRegex = re.compile(r'fallback_to_topology_keys_only( )*=( )*([a-z]*[A-Z]*)*( )?')
+            ri_string = FallbackToTopologyKeysOnlyRegex.search(self.originalDSN)
+            if ri_string != None:
+                ri_string = ri_string.group()
+                ri_parts = ri_string.split(self.EQUALS)
+                ri_parts = list(filter(('').__ne__, ri_parts))
+                propValue = ri_parts[1].lower().strip()
+                if propValue == 'true':
+                    self.fallback_to_topology_keys_only = True
+                sb = FallbackToTopologyKeysOnlyRegex.sub('', sb)
         return sb
         
     def processProperties(self):
@@ -73,14 +85,21 @@ class LoadBalanceProperties:
         if 'load_balance' in backup_dict:
             propValue = backup_dict.pop('load_balance')
             propValue = propValue.lower().strip()
-            if propValue == 'true':
-                self.loadbalance = True
+            if (propValue == 'true' or propValue == 'any' or propValue == 'only-rr' or propValue == 'only-primary' or propValue == 'prefer-rr' or propValue == 'prefer-primary' or propValue == 'false'):
+                self.loadbalance = propValue
+            else : 
+                raise ValueError('invalid load_balance value: Valid values are only-rr, only-primary, prefer-rr, prefer-primary, any or true')
             if 'topology_keys' in backup_dict:
                 self.placements = backup_dict.pop('topology_keys')
             if 'yb_servers_refresh_interval' in backup_dict:
                 self.refreshInterval = int(backup_dict.pop('yb_servers_refresh_interval'))
             if 'failed_host_ttl_seconds' in backup_dict:
                 self.refreshInterval = int(backup_dict.pop('failed_host_ttl_seconds'))
+            if 'fallback_to_topology_keys_only' in backup_dict:
+                propValue = backup_dict.pop('fallback_to_topology_keys_only')
+                propValue = propValue.lower().strip()
+                if propValue == 'true':
+                    self.fallback_to_topology_keys_only = True
         return backup_dict
 
 
@@ -100,21 +119,26 @@ class LoadBalanceProperties:
         return self.key
 
     def hasLoadBalance(self):
-        return self.loadbalance
+        return self.loadbalance != 'false'
 
     def getAppropriateLoadBalancer(self):
         if self.placements == '':
-            ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.SIMPLE_LB)
+            ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.loadbalance)
             if ld == None:
-                ld = ClusterAwareLoadBalancer.getInstance(self.refreshInterval, self.failed_host_ttl_seconds)
-                LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.SIMPLE_LB] = ld
-            self.key = self.SIMPLE_LB
+                ld = ClusterAwareLoadBalancer(self.loadbalance, self.refreshInterval, self.failed_host_ttl_seconds)
+                LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.loadbalance] = ld
+            self.key = self.loadbalance
         else:
-            ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(self.placements)
+            lbKey = ""
+            if self.fallback_to_topology_keys_only:
+                lbKey = self.loadbalance + "&" + self.placements + "&True"
+            else:
+                lbKey = self.loadbalance + "&" + self.placements + "&False"
+            ld = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(lbKey)
             if ld == None :
-                ld = TopologyAwareLoadBalancer(self.placements, self.refreshInterval, self.failed_host_ttl_seconds)
-                LoadBalanceProperties.CONNECTION_MANAGER_MAP[self.placements] = ld
-            self.key = self.placements
+                ld = TopologyAwareLoadBalancer(self.loadbalance, self.placements, self.refreshInterval, self.failed_host_ttl_seconds, self.fallback_to_topology_keys_only)
+                LoadBalanceProperties.CONNECTION_MANAGER_MAP[lbKey] = ld
+            self.key = lbKey
         return ld
     
     def getAppropriateLoadBalancerToCloseConnection(self, lb_key):

--- a/lib/loadbalanceproperties.py
+++ b/lib/loadbalanceproperties.py
@@ -139,6 +139,8 @@ class LoadBalanceProperties:
                 ld = TopologyAwareLoadBalancer(self.loadbalance, self.placements, self.refreshInterval, self.failed_host_ttl_seconds, self.fallback_to_topology_keys_only)
                 LoadBalanceProperties.CONNECTION_MANAGER_MAP[lbKey] = ld
             self.key = lbKey
+            ld.refreshListSeconds = self.refreshInterval if self.refreshInterval >= 0 and self.refreshInterval <= 600 else 300
+            ld.failedHostsTTL = self.failed_host_ttl_seconds if self.failed_host_ttl_seconds >= 0 and self.failed_host_ttl_seconds <= 60 else 5
         return ld
     
     def getAppropriateLoadBalancerToCloseConnection(self, lb_key):

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -21,7 +21,7 @@ class ClusterAwareLoadBalancer:
     
     def __init__(self, loadBalance, refreshInterval, failedHostTTL):
         self.loadBalance = loadBalance
-        self.failedHostsTTL = failedHostTTL if failedHostTTL > 0 else 5
+        self.failedHostsTTL = failedHostTTL if failedHostTTL >= 0 and failedHostTTL <= 60 else 5
         self.lastServerListFetchTime = 0
         self.servers = []
         self.primaryNodes = []
@@ -35,7 +35,7 @@ class ClusterAwareLoadBalancer:
         self.unreachableHosts = {}
         self.currentPrivateIps = {}
         self.currentPublicIps = {}
-        self.refreshListSeconds = refreshInterval if refreshInterval > 0 and refreshInterval < 600 else 300
+        self.refreshListSeconds = refreshInterval if refreshInterval >= 0 and refreshInterval <= 600 else 300
         self.useHostColumn = None
     
     def getPort(self, host):
@@ -305,8 +305,8 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
         self.allowedPlacements = {}
         self.fallbackPrivateIPs = {}
         self.fallbackPublicIPs = {}
-        self.refreshListSeconds = refreshInterval if refreshInterval > 0 and refreshInterval < 600 else 300
-        self.failedHostsTTL = failedHostTTL
+        self.refreshListSeconds = refreshInterval if refreshInterval >= 0 and refreshInterval <= 600 else 300
+        self.failedHostsTTL = failedHostTTL if failedHostTTL >= 0 and failedHostTTL <= 60 else 5
         self.parseGeoLocations()
 
     def parseGeoLocations(self):
@@ -407,7 +407,7 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
         return self.getPrivateOrPublicServers(self.useHostColumn, self.currentPrivateIps, self.currentPublicIps)
 
     def hasMorePreferredNodes(self, chosenHost):
-        if self.loadBalance == 'only-rr' or self.loadBalance == 'prefer-rr' or self.loadBalance == 'any':
+        if self.loadBalance == 'only-rr' or self.loadBalance == 'prefer-rr' or self.loadBalance == 'any' or self.loadBalance == 'true':
             if chosenHost in self.hostToPriorityMapRR:
                 chosenHostPriority = self.hostToPriorityMapRR.get(chosenHost)
                 if chosenHostPriority != None :
@@ -415,7 +415,7 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
                         if i in self.hostToPriorityMapRR.values():
                             return True
         
-        if self.loadBalance == 'only-primary' or self.loadBalance == 'prefer-primary' or self.loadBalance == 'any':
+        if self.loadBalance == 'only-primary' or self.loadBalance == 'prefer-primary' or self.loadBalance == 'any' or self.loadBalance == 'true':
             if chosenHost in self.hostToPriorityMapPrimary:
                 chosenHostPriority = self.hostToPriorityMapPrimary.get(chosenHost)
                 if chosenHostPriority != None :

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 # Take a look at https://www.python.org/dev/peps/pep-0440/
 # for a consistent versioning pattern.
 
-PSYCOPG_VERSION = '2.9.3.3'
+PSYCOPG_VERSION = '2.9.3.4'
 
 
 # note: if you are changing the list of supported Python version please fix

--- a/tests/test_fallback_topology.py
+++ b/tests/test_fallback_topology.py
@@ -54,7 +54,9 @@ def create_connections(url, tkValue, counts):
     
     verifyLocalConnections(counts, tkValue, 0)
 
-def verifyLocalConnections(counts, key, k):
+def verifyLocalConnections(counts, tkValue, k):
+
+    key = "true&" + tkValue + "&False"
     
     try:
         if key not in LoadBalanceProperties.CONNECTION_MANAGER_MAP:

--- a/tests/test_rr1.py
+++ b/tests/test_rr1.py
@@ -1,0 +1,226 @@
+import json
+import os
+import subprocess
+import unittest
+import time
+from urllib.request import urlopen
+from psycopg2.loadbalanceproperties import LoadBalanceProperties
+
+import psycopg2
+
+base_url = "host=127.0.0.1,127.0.0.4 port=5433 user=yugabyte dbname=yugabyte yb_servers_refresh_interval=1 "
+yb_install_path = os.getenv('YB_PATH')
+num_connections = 12
+control_host = "127.0.0.1"
+
+def create_rr_cluster():
+    
+    print("Destroying earlier YBDB cluster, if any ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop earlier YBDB cluster", 10, "destroy")
+    
+    print("Starting a YBDB cluster with rf=3 ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not start YBDB cluster", 30, "create", "--rf", "3", 
+              "--placement_info", "cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1", 
+              "--tserver_flags", "placement_uuid=live,max_stale_read_bound_time_ms=60000000")
+
+    print("Configuring the YBDB cluster ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-admin", "Could not configure YBDB cluster", 10, 
+              "-master_addresses", "127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100", 
+              "modify_placement_info", "cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1", "3", "live")
+
+    for i in range(2, 5):
+        print(f"Adding RR node to the YBDB cluster ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not add a RR node to the YBDB cluster", 15, 
+                  "add_node", "--placement_info", f"cloud1.datacenter{i}.rack1", "--tserver_flags", "placement_uuid=rr")
+
+    print("Configuring the RR YBDB cluster ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-admin", "Could not configure RR cluster", 10, 
+              "-master_addresses", "127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100", 
+              "add_read_replica_placement_info", "cloud1.datacenter2.rack1,cloud1.datacenter3.rack1,cloud1.datacenter4.rack1", "3", "rr")
+
+    print("Started the cluster!")
+
+def main():
+
+    print("Starting startRRExample1() ...")
+    create_rr_cluster()
+    try:
+        new_conn = [None] * 12
+
+        urls = [
+            f"{base_url}load_balance=false",
+            f"{base_url}load_balance=any",
+            f"{base_url}load_balance=only-rr",
+            f"{base_url}load_balance=only-primary",
+            f"{base_url}load_balance=prefer-rr",
+            f"{base_url}load_balance=prefer-primary",
+        ]
+
+        expected_results = [
+            [12, 0, 0, 0, 0, 0],
+            [2, 2, 2, 2, 2, 2],
+            [0, 0, 0, 4, 4, 4],
+            [4, 4, 4, 0, 0, 0],
+            [0, 0, 0, 4, 4, 4],
+            [4, 4, 4, 0, 0, 0]
+        ]
+
+        keys = [
+            'false',
+            'any',
+            'only-rr',
+            'only-primary',
+            'prefer-rr',
+            'prefer-primary'
+        ]
+
+        for url, key, expected in zip(urls, keys, expected_results):
+            print(f"Using connection url: {url}")
+            create_connections(url, key, expected)
+
+        # Stopping RR servers
+        for i in range(4, 7):
+            print(f"Stopping RR server {i} ...")
+            exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(i))
+
+        time.sleep(6)
+        
+        url = f"{base_url}load_balance=prefer-rr"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-rr', [4, 4, 4, 0, 0, 0])
+
+        url = f"{base_url}load_balance=only-rr"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-rr', [])
+
+        # Restarting nodes
+        for i in [5, 4, 6]:
+            print(f"Restarting RR node {i}...")
+            exec_cmd(f"{yb_install_path}/bin/yb-ctl", f"Could not restart RR node {i}", 20, "start_node", str(i), "--placement_info", f"cloud1.datacenter{(i-4)}.rack1")
+
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=any"
+        print(f"Using connection url: {url}")
+        create_connections(url, 'any', [2, 2, 2, 2, 2, 2])
+
+        # Stopping primary servers
+        for i in range(1, 4):
+            print(f"Stopping primary server {i} ...")
+            exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(i))
+        
+        time.sleep(6)
+        control_host = "127.0.0.4"
+
+        url = f"{base_url}load_balance=prefer-primary"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-primary', [0, 0, 0, 4, 4, 4])
+
+        url = f"{base_url}load_balance=only-primary"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-primary', [])
+
+        print("Closing the application ...")
+    finally:
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not destroy the YBDB cluster", 10, "status")
+    
+
+def exec_cmd(command, error_message, timeout, *args):
+    try:
+        subprocess.run([command] + list(args), check=True, timeout=timeout)
+    except subprocess.CalledProcessError:
+        print(error_message)
+
+def create_connections(url, key, counts):
+    connections = []
+    for i in range(num_connections):
+        try:
+            conn  = psycopg2.connect(url)
+            connections.append(conn)
+        except psycopg2.OperationalError as e:
+            if len(counts) == 0:
+                error_message = str(e)  # Convert the error object to string to get the message
+
+                if "Could not find a server to connect to." in error_message:
+                    print("Got expected exception")
+                else:
+                    print(f"Some other error occurred: {error_message}")
+                    exit(1)
+            else:
+                print(f"Some error occurred: {e}")
+                exit(1)
+    
+    print(f"Created {num_connections} connections")
+
+    j = 1
+    for count in counts:
+        if count != -1 :
+            host = '127.0.0.' + str(j)
+            verifyOn(host, count)
+        
+        j = j + 1
+
+    if key != 'false':
+        verifyLocalConnections(counts, key, 1)
+    
+    for conn1 in connections:
+        conn1.close()
+
+    if key != 'false':
+        verifyLocalConnections(counts, key, 0)
+
+def verifyOn(server, expectedCount):
+    count = 0
+    url = "http://" + server + ":13000/rpcz"
+    print(url)
+    try:
+        try:
+            response = urlopen(url)
+        except Exception as ax:
+            if expectedCount != 0:
+                print(f'{ex}')
+                exit(1)
+            else:
+                return
+        data_json = json.loads(response.read())
+        for connection in data_json["connections"]:
+            if connection["backend_type"] == "client backend":
+                count = count + 1
+        print(f"{server}:{count}")
+        if not count == expectedCount:
+            if server == control_host:
+                if not count == expectedCount + 1:
+                    raise Exception("host: " + server + " Expected Count: "+ str(expectedCount) + " actualCount: " + str(count))
+            else:
+                raise Exception("host: " + server + " Expected Count: "+ str(expectedCount) + " actualCount: " + str(count))
+    except Exception as ex:
+        print(f'{ex}')
+        exit(1)
+
+def verifyLocalConnections(counts, key, k):
+    
+    try:
+        if key not in LoadBalanceProperties.CONNECTION_MANAGER_MAP:
+            raise Exception("Error: Load Balancer instance not found in CONNECTION_MANAGER_MAP")
+        
+        load_balance_instance = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(key)
+        expected_counts = load_balance_instance.hostToNumConnMap
+
+        j = 1
+        for count in counts:
+            if count != -1 and count != 0:
+                host = '127.0.0.' + str(j)
+                if host in expected_counts:
+                    if expected_counts.get(host) != count * k:
+                        raise Exception("host: " + host + " expected Count in hostToNumConnMap: "+ str(count) + " actualCount: " + str(expected_counts.get(host)))
+                else:
+                    raise Exception("host: " + host + " not found in hostToNumConnMap")
+            j = j + 1
+
+    except Exception as ex:
+        print(expected_counts)
+        print(f'{ex}')
+        exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rr2.py
+++ b/tests/test_rr2.py
@@ -1,0 +1,328 @@
+import json
+import os
+import subprocess
+import unittest
+import time
+from urllib.request import urlopen
+from psycopg2.loadbalanceproperties import LoadBalanceProperties
+
+import psycopg2
+
+base_url = "host=127.0.0.1,127.0.0.4 port=5433 user=yugabyte dbname=yugabyte yb_servers_refresh_interval=1 "
+yb_install_path = os.getenv('YB_PATH')
+num_connections = 12
+control_host = "127.0.0.1"
+
+def create_rr_cluster():
+    
+    print("Destroying earlier YBDB cluster, if any ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop earlier YBDB cluster", 10, "destroy")
+    
+    print("Starting a YBDB cluster with rf=3 ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not start YBDB cluster", 30, "create", "--rf", "3", 
+              "--placement_info", "cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1", 
+              "--tserver_flags", "placement_uuid=live,max_stale_read_bound_time_ms=60000000")
+
+    print("Configuring the YBDB cluster ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-admin", "Could not configure YBDB cluster", 10, 
+              "-master_addresses", "127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100", 
+              "modify_placement_info", "cloud1.datacenter1.rack1,cloud1.datacenter2.rack1,cloud1.datacenter3.rack1", "3", "live")
+
+    for i in range(2, 5):
+        print(f"Adding RR node to the YBDB cluster ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not add a RR node to the YBDB cluster", 15, 
+                  "add_node", "--placement_info", f"cloud1.datacenter{i}.rack1", "--tserver_flags", "placement_uuid=rr")
+
+    print("Configuring the RR YBDB cluster ...")
+    exec_cmd(f"{yb_install_path}/bin/yb-admin", "Could not configure RR cluster", 10, 
+              "-master_addresses", "127.0.0.1:7100,127.0.0.2:7100,127.0.0.3:7100", 
+              "add_read_replica_placement_info", "cloud1.datacenter2.rack1,cloud1.datacenter3.rack1,cloud1.datacenter4.rack1", "3", "rr")
+
+    print("Started the cluster!")
+
+def main():
+
+    print("Starting startRRExample1() ...")
+    create_rr_cluster()
+    time.sleep(6)
+    try:
+        new_conn = [None] * 12
+
+        urls = [
+            f"{base_url}load_balance=false",
+            f"{base_url}load_balance=any topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2",
+            f"{base_url}load_balance=only-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2",
+            f"{base_url}load_balance=only-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2",
+            f"{base_url}load_balance=prefer-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2",
+            f"{base_url}load_balance=prefer-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2",
+        ]
+
+        expected_results = [
+            [12, 0, 0, 0, 0, 0],
+            [0, 6, 0, 6, 0, 0],
+            [0, 0, 0, 12, 0, 0],
+            [0, 12, 0, 0, 0, 0],
+            [0, 0, 0, 12, 0, 0],
+            [0, 12, 0, 0, 0, 0],
+        ]
+
+        keys = [
+            'false',
+            'any&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False',
+            'only-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False',
+            'only-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False',
+            'prefer-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False',
+            'prefer-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False'
+        ]
+
+        for url, key, expected in zip(urls, keys, expected_results):
+            print(f"Using connection url: {url}")
+            create_connections(url, key, expected)
+
+        print(f"Stopping RR server 4 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(4))
+        time.sleep(6)
+        
+        url = f"{base_url}load_balance=prefer-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 0, 12, 0])
+        
+        url = f"{base_url}load_balance=only-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 0, 12, 0])
+
+        print(f"Stopping RR server 5 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(5))
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=prefer-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 0, 0, 12])
+        
+        url = f"{base_url}load_balance=only-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 0, 0, 12])
+
+        url = f"{base_url}load_balance=only-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2 fallback_to_topology_keys_only=true"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [])
+
+        print(f"Stopping RR server 6 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(6))
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=prefer-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [4, 4, 4, 0, 0, 0])
+
+        print(f"Restarting RR node 5...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not restart RR node 5", 20, "start_node", str(5), "--placement_info", "cloud1.datacenter3.rack1")
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=prefer-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 0, 12, 0])
+        
+        url = f"{base_url}load_balance=only-rr topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-rr&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 0, 12, 0])
+
+        print(f"Restarting RR node 4...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", f"Could not restart RR node 4", 20, "start_node", str(4), "--placement_info", f"cloud1.datacenter2.rack1")
+        time.sleep(6)
+
+        print(f"Restarting RR node 6...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", f"Could not restart RR node 6", 20, "start_node", str(6), "--placement_info", f"cloud1.datacenter4.rack1")
+        time.sleep(6)
+
+        print(f"Stopping primary server 2 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(2))
+        time.sleep(6)
+
+        control_host = "127.0.0.4"
+
+        url = f"{base_url}load_balance=prefer-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 12, 0, 0, 0])
+        
+        url = f"{base_url}load_balance=only-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 12, 0, 0, 0])
+
+        print(f"Stopping primary server 3 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(3))
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=prefer-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [12, 0, 0, 0, 0, 0])
+        
+        url = f"{base_url}load_balance=only-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [12, 0, 0, 0, 0, 0])
+
+        url = f"{base_url}load_balance=only-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2 fallback_to_topology_keys_only=true"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [])
+
+        print(f"Stopping primary server 1 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(1))
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=prefer-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 4, 4, 4])
+
+        print(f"Restarting Primary node 3...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not restart Primary node 3", 20, "start_node", str(3), "--placement_info", "cloud1.datacenter3.rack1","--tserver_flags", "placement_uuid=live")
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=prefer-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'prefer-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 12, 0, 0, 0])
+        
+        url = f"{base_url}load_balance=only-primary topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'only-primary&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 12, 0, 0, 0])
+
+        print(f"Restarting Primary node 1...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not restart Primary node 1", 20, "start_node", str(1), "--placement_info", "cloud1.datacenter1.rack1","--tserver_flags", "placement_uuid=live")
+        time.sleep(6)
+
+        print(f"Stopping RR server 4 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(4))
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=any topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'any&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 6, 0, 6, 0])
+
+        print(f"Stopping RR server 5 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(5))
+        time.sleep(6)
+
+        print(f"Stopping primary server 3 ...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not stop the YBDB server", 10, "stop_node", str(3))
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=any topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'any&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [6, 0, 0, 0, 0, 6])
+
+        url = f"{base_url}load_balance=any topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2 fallback_to_topology_keys_only=true"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'any&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [])
+
+        print(f"Restarting RR node 4...")
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", f"Could not restart RR node 4", 20, "start_node", str(4), "--placement_info", f"cloud1.datacenter2.rack1")
+        time.sleep(6)
+
+        url = f"{base_url}load_balance=any topology_keys=cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2"
+        print(f"Using connection url:\n    {url}")
+        create_connections(url, 'any&cloud1.datacenter2.rack1:1,cloud1.datacenter3.rack1:2&False', [0, 0, 0, 12, 0, 0])
+
+        print("Closing the application ...")
+
+    finally:
+        exec_cmd(f"{yb_install_path}/bin/yb-ctl", "Could not destroy the YBDB cluster", 10, "status")
+    
+
+def exec_cmd(command, error_message, timeout, *args):
+    try:
+        subprocess.run([command] + list(args), check=True, timeout=timeout)
+    except subprocess.CalledProcessError:
+        print(error_message)
+
+def create_connections(url, key, counts):
+    connections = []
+    for i in range(num_connections):
+        try:
+            conn  = psycopg2.connect(url)
+            connections.append(conn)
+        except psycopg2.OperationalError as e:
+            if len(counts) == 0:
+                error_message = str(e)  # Convert the error object to string to get the message
+
+                if "Could not find a server to connect to." in error_message:
+                    print("Got expected exception")
+                else:
+                    print(f"Some other error occurred: {error_message}")
+                    exit(1)
+            else:
+                print(f"Some error occurred: {e}")
+                exit(1)
+    
+    print(f"Created {num_connections} connections")
+
+    j = 1
+    for count in counts:
+        if count != -1 :
+            host = '127.0.0.' + str(j)
+            verifyOn(host, count)
+        
+        j = j + 1
+
+    if key != 'false':
+        verifyLocalConnections(counts, key, 1)
+    
+    for conn1 in connections:
+        conn1.close()
+
+    if key != 'false':
+        verifyLocalConnections(counts, key, 0)
+
+def verifyOn(server, expectedCount):
+    count = 0
+    url = "http://" + server + ":13000/rpcz"
+    print(url)
+    try:
+        try:
+            response = urlopen(url)
+        except Exception as ax:
+            if expectedCount != 0:
+                print(f'{ex}')
+                exit(1)
+            else:
+                return
+        data_json = json.loads(response.read())
+        for connection in data_json["connections"]:
+            if connection["backend_type"] == "client backend":
+                count = count + 1
+        print(f"{server}:{count}")
+        if not count == expectedCount:
+            if server == control_host:
+                if not count == expectedCount + 1:
+                    raise Exception("host: " + server + " Expected Count: "+ str(expectedCount) + " actualCount: " + str(count))
+            else:
+                raise Exception("host: " + server + " Expected Count: "+ str(expectedCount) + " actualCount: " + str(count))
+    except Exception as ex:
+        print(f'{ex}')
+        exit(1)
+        
+def verifyLocalConnections(counts, key, k):
+    
+    try:
+        if key not in LoadBalanceProperties.CONNECTION_MANAGER_MAP:
+            raise Exception("Error: Load Balancer instance not found in CONNECTION_MANAGER_MAP")
+        
+        load_balance_instance = LoadBalanceProperties.CONNECTION_MANAGER_MAP.get(key)
+        expected_counts = load_balance_instance.hostToNumConnMap
+
+        j = 1
+        for count in counts:
+            if count != -1 and count != 0:
+                host = '127.0.0.' + str(j)
+                if host in expected_counts:
+                    if expected_counts.get(host) != count * k:
+                        raise Exception("host: " + host + " expected Count in hostToNumConnMap: "+ str(count) + " actualCount: " + str(expected_counts.get(host)))
+                else:
+                    raise Exception("host: " + host + " not found in hostToNumConnMap")
+            j = j + 1
+
+    except Exception as ex:
+        print(expected_counts)
+        print(f'{ex}')
+        exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
IDEA: [IDEA-1196](https://yugabyte.atlassian.net/browse/IDEA-1196)

Implementation details: [Doc](https://docs.google.com/document/d/1SqT7IMM5DuHav7fl_xGt8pfCMp5dnJ6-MrLVftbIows/edit#heading=h.4p1zl0z1krwh)

The connection property `load_balance` currently allows only two values, viz. `false` (the default) and `true`.

It will now also allow below five new values to be specified:
`only-rr` - Create connections only on Read Replica nodes
`only-primary`- Create connections only on primary cluster nodes
`prefer-rr` - Create connections on Read Replica nodes. If none available, on any node in the cluster including primary cluster nodes
`prefer-primary` - Create connections on primary cluster nodes. If none available, on any node in the cluster including Read Replica nodes
`any` - Equivalent to value true. Create connections on any node in the primary or Read Replica cluster

default value is still `false`

[DB-12859](https://yugabyte.atlassian.net/browse/DB-12859): This PR also adds a new connection property `fallback_to_topology_keys_only`: Applicable only for TopologyAware Load Balancing when `load_balance` value is either of the following: `only-rr`, `only-primary`, `any` or `true`. For more details refer to this [doc](https://docs.google.com/document/d/1SqT7IMM5DuHav7fl_xGt8pfCMp5dnJ6-MrLVftbIows/edit#heading=h.4p1zl0z1krwh).
When set to true, the smart driver does not attempt to connect to servers outside of primary and fallback placements specified via `topology_keys` property. 
The default behaviour is to fallback to any available server of the required type (primary or read replica) in the entire cluster.

**Testing:**

- Test cases identified and listed in this [doc](https://docs.google.com/document/d/1B1S571qun4au6gXJ91rqD1DDrPVdr7-GjcbWWADjsl8/edit?usp=sharing): TestS for all test cases listed in the doc added as part of this PR in `test_rr1.py`: RR tests for CALB and `test_rr2.py`: RR tests for TALB.

- Ran the existing tests in driver examples repo for psycopg2. (Required minor test changes: [Driver-examples PR](https://github.com/yugabyte/driver-examples/pull/38))

- Ran `test_fallback_topplogy.py`