### PR TITLE
Remove append to `currentPublicIps` dict

### DIFF
--- a/lib/policies.py
+++ b/lib/policies.py
@@ -513,7 +513,6 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
             self.populateHosts(currentPrivateIps, host, node_type)
             if len(public_host.strip()) != 0:
                 self.populateHosts(currentPublicIps, public_host, node_type)
-                currentPublicIps.append(public_host)
         else:
             for key,value in self.allowedPlacements.items():
                 if self.checkIfPresent(cp, value):

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 # Take a look at https://www.python.org/dev/peps/pep-0440/
 # for a consistent versioning pattern.
 
-PSYCOPG_VERSION = '2.9.3.4'
+PSYCOPG_VERSION = '2.9.3.5'
 
 
 # note: if you are changing the list of supported Python version please fix


### PR DESCRIPTION
JIRA: [DB-14351](https://yugabyte.atlassian.net/browse/DB-14351)

## What: 
- `currentPublicIps` holds the public ip address of each node from the Primary placement.
- When we added support for node-type aware load balancing, we changed `currentPublicIps` from a list to a dict.
- This PR removes the append operation on `currentPublicIps` since it is not allowed for dict data type.

## Why:
- This was causing the application using Topology aware load balancing to fail with `AttributeError: 'dict' object has no attribute 'append'` in a setup where the servers have a assigned public address.

## Testing:
- Wrote a new test case with reproduced the same error. [PR](https://github.com/yugabyte/driver-examples/pull/44)
- Existing driver-example tests pass