### PR TITLE
Bug fixes when using public IPs

### DIFF
--- a/lib/policies.py
+++ b/lib/policies.py
@@ -131,9 +131,9 @@ class ClusterAwareLoadBalancer:
             return "select * from yb_servers()"
 
     def getCurrentServers(self, conn):
-        GET_SERVERS_QUERY = self.getRefreshQuery()
+        getServersQuery = self.getRefreshQuery()
         cur = conn.cursor()
-        cur.execute(GET_SERVERS_QUERY)
+        cur.execute(getServersQuery)
         rs = cur.fetchall()
         hostConnectedTo = conn.info.host_addr
         isIpv6Addresses = ':' in hostConnectedTo
@@ -393,9 +393,9 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
 
     
     def getCurrentServers(self, conn):
-        GET_SERVERS_QUERY = self.getRefreshQuery()
+        getServersQuery = self.getRefreshQuery()
         cur = conn.cursor()
-        cur.execute(GET_SERVERS_QUERY)
+        cur.execute(getServersQuery)
         rs = cur.fetchall()
         hostConnectedTo = conn.info.host_addr
         isIpv6Addresses = ':' in hostConnectedTo

--- a/lib/policies.py
+++ b/lib/policies.py
@@ -43,11 +43,32 @@ class ClusterAwareLoadBalancer:
         if port == None :
             port = self.hostPortMap_public.get(host)
         return port
+
+    def checkCurrentPublicIps(self):
+        primaryhostlist = 0
+        rrhostlist = 0
+        if('primary' in self.currentPublicIps):
+            primaryhostlist = len(self.checkCurrentPublicIps['primary'])
+        if('read_replica' in self.currentPublicIps):
+            rrhostlist = len(self.checkCurrentPublicIps['read_replica'])
+        
+        if primaryhostlist == 0 and rrhostlist == 0:
+            return False
+        if self.loadBalance == 'only-primary' and primaryhostlist == 0:
+            return False
+        if self.loadBalance == 'only-rr' and rrhostlist == 0:
+            return False
+                
+        return True
     
     def getLeastLoadedServer(self,failedhosts):
         if not self.hostToNumConnMap:
             privatehosts = {}
-            self.servers = self.getPrivateOrPublicServers(self.useHostColumn, privatehosts, self.currentPublicIps)
+            if self.useHostColumn == True:
+                publichosts = self.currentPublicIps
+            else:
+                publichosts = {}
+            self.servers = self.getPrivateOrPublicServers(self.useHostColumn, privatehosts, publichosts)
             if self.servers:
                 for h in self.servers:
                     if not h in self.hostToNumConnMap.keys():
@@ -55,7 +76,7 @@ class ClusterAwareLoadBalancer:
                             self.hostToNumConnMap[h] = self.hostToNumConnCount[h]
                         else:
                             self.hostToNumConnMap[h] = 0
-            elif not self.loadBalance in self.currentPublicIps:
+            elif not self.checkCurrentPublicIps():
                 return '' 
         chosenHost = ''
         minConnectionsHostList = []
@@ -79,8 +100,7 @@ class ClusterAwareLoadBalancer:
             self.updateConnectionMap(chosenHost,1)
         elif self.useHostColumn == None:
             newList = []
-            if self.loadBalance in self.currentPublicIps:
-                newList = newList + self.currentPublicIps[self.loadBalance]
+            newList = newList + self.getAppropriateHosts(self.currentPublicIps, False)
             if newList:
                 self.useHostColumn = False
                 self.servers = newList
@@ -140,21 +160,33 @@ class ClusterAwareLoadBalancer:
             zone = row[6]
             port = row[1]
             self.hostPortMap[host_addr] = port
-            self.updatePriorityMap(host_addr,cloud,region,zone,node_type)
             self.hostPortMap_public[public_host_addr] = port
-            if not host_addr in self.unreachableHosts.keys():
-                if node_type == 'primary':
-                    self.primaryNodes.append(host)
-                else:
-                    self.rrNodes.append(host)
-                self.populateHosts(self.currentPrivateIps, host_addr, node_type)
-                if public_host_addr:
-                    self.populateHosts(self.currentPublicIps, public_host_addr, node_type)
+
             if self.useHostColumn == None :
                 if hostConnectedTo == host_addr :
                     self.useHostColumn = True
                 elif hostConnectedTo == public_host_addr :
                     self.useHostColumn = False
+            
+            if self.useHostColumn == False:
+                self.updatePriorityMap(public_host_addr,cloud,region,zone,node_type)
+            else:
+                self.updatePriorityMap(host_addr,cloud,region,zone,node_type)
+
+            if not host_addr in self.unreachableHosts.keys():
+                if node_type == 'primary':
+                    if self.useHostColumn == False:
+                        self.primaryNodes.append(public_host)
+                    else:
+                        self.primaryNodes.append(host)
+                else:
+                    if self.useHostColumn == False:
+                        self.rrNodes.append(public_host)
+                    else:
+                        self.rrNodes.append(host)
+                self.populateHosts(self.currentPrivateIps, host_addr, node_type)
+                if public_host_addr:
+                    self.populateHosts(self.currentPublicIps, public_host_addr, node_type)
         
         return self.getPrivateOrPublicServers(self.useHostColumn, self.currentPrivateIps, self.currentPublicIps)
         
@@ -391,19 +423,31 @@ class TopologyAwareLoadBalancer(ClusterAwareLoadBalancer):
             zone = row[6]
             port = row[1]
             self.hostPortMap[host_addr] = port
-            self.updatePriorityMap(host_addr, cloud, region, zone, node_type)
             self.hostPortMap_public[public_host_addr] = port
-            if not host_addr in self.unreachableHosts:
-                if node_type == 'primary':
-                    self.primaryNodes.append(host)
-                else:
-                    self.rrNodes.append(host)
-                self.updateCurrentHostList(self.currentPrivateIps, self.currentPublicIps, host_addr, public_host_addr, cloud, region, zone, node_type)
+
             if self.useHostColumn == None :
                 if hostConnectedTo == host_addr :
                     self.useHostColumn = True
                 elif hostConnectedTo == public_host_addr :
                     self.useHostColumn = False
+            
+            if self.useHostColumn == False:
+                self.updatePriorityMap(public_host_addr,cloud,region,zone,node_type)
+            else:
+                self.updatePriorityMap(host_addr,cloud,region,zone,node_type)
+
+            if not host_addr in self.unreachableHosts:
+                if node_type == 'primary':
+                    if self.useHostColumn == False:
+                        self.primaryNodes.append(public_host)
+                    else:
+                        self.primaryNodes.append(host)
+                else:
+                    if self.useHostColumn == False:
+                        self.rrNodes.append(public_host)
+                    else:
+                        self.rrNodes.append(host)
+                self.updateCurrentHostList(self.currentPrivateIps, self.currentPublicIps, host_addr, public_host_addr, cloud, region, zone, node_type)
         return self.getPrivateOrPublicServers(self.useHostColumn, self.currentPrivateIps, self.currentPublicIps)
 
     def hasMorePreferredNodes(self, chosenHost):


### PR DESCRIPTION
Following bugs are fixed as part of this PR:

- If `useHostColumn` is `False` add public IPs in `primaryNodes`,  `rrNodes`, `hostToPriorityMapPrimary` and `hostToPriorityMapRR`.
- Correctly check if there are any primary or read-replica nodes in currentPublicIps.
- if `useHostColumn` is not `True`, empty `currentPublicIps` to fallback to next fallback zones.\

Using a env variable `TEST_YB_PUBLIC_IP`  to change the refresh query to simulate a cluster with public_ip configured in tests.

**Testing**

- Added a new test case: [PR](https://github.com/yugabyte/driver-examples/pull/47)
- Ran the existing tests in driver-examples repo.